### PR TITLE
Initialize Django project with deployment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DEBUG=1
+SECRET_KEY=changeme-secret-key
+DATABASE_URL=postgresql://user:password@localhost:5432/jobtracker
+ALLOWED_HOSTS=localhost,127.0.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+.env
+venv/
+staticfiles/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use official Python image.
+FROM python:3.12-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Install dependencies
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project
+COPY . .
+
+# Collect static files
+RUN python jobtracker/manage.py collectstatic --noinput || true
+
+# Run the application
+CMD gunicorn jobtracker.wsgi:application --bind 0.0.0.0:$PORT

--- a/jobtracker/jobtracker/asgi.py
+++ b/jobtracker/jobtracker/asgi.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'jobtracker.settings')
+
+application = get_asgi_application()

--- a/jobtracker/jobtracker/settings.py
+++ b/jobtracker/jobtracker/settings.py
@@ -1,0 +1,84 @@
+import os
+from pathlib import Path
+
+import dj_database_url
+from dotenv import load_dotenv
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Load environment variables from .env file if present
+load_dotenv(BASE_DIR / '.env')
+
+SECRET_KEY = os.environ.get('SECRET_KEY', 'changeme-secret-key')
+
+DEBUG = os.environ.get('DEBUG', '0') == '1'
+
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost').split(',')
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ROOT_URLCONF = 'jobtracker.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = 'jobtracker.wsgi.application'
+
+DATABASES = {
+    'default': dj_database_url.config(default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}")
+}
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/jobtracker/jobtracker/urls.py
+++ b/jobtracker/jobtracker/urls.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+]

--- a/jobtracker/jobtracker/wsgi.py
+++ b/jobtracker/jobtracker/wsgi.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'jobtracker.settings')
+
+application = get_wsgi_application()

--- a/jobtracker/manage.py
+++ b/jobtracker/manage.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import os
+import sys
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'jobtracker.settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and available on your PYTHONPATH environment variable? Did you forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+if __name__ == '__main__':
+    main()

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,19 @@
+services:
+  - type: web
+    name: jobtracker
+    env: python
+    plan: free
+    buildCommand: "pip install -r requirements.txt && python jobtracker/manage.py collectstatic --no-input"
+    startCommand: "gunicorn jobtracker.wsgi:application"
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: jobtracker-db
+          property: connectionString
+      - key: SECRET_KEY
+        generateValue: true
+      - key: DEBUG
+        value: "0"
+databases:
+  - name: jobtracker-db
+    plan: free

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Django>=5.0,<6.0
+dj-database-url
+gunicorn
+psycopg2-binary
+python-dotenv


### PR DESCRIPTION
## Summary
- bootstrap Django "jobtracker" project
- add Dockerfile, requirements, and Render blueprint for deployment
- configure settings to read database and secret values from environment

## Testing
- `python3 jobtracker/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b100e6b65c8330bc683182c589d5c0