### PR TITLE
Add email-based ContractorUser model and authentication backend

### DIFF
--- a/jobtracker/jobtracker/settings.py
+++ b/jobtracker/jobtracker/settings.py
@@ -59,6 +59,9 @@ DATABASES = {
     'default': dj_database_url.config(default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}")
 }
 
+AUTH_USER_MODEL = 'tracker.ContractorUser'
+AUTHENTICATION_BACKENDS = ['tracker.backends.EmailBackend']
+
 AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',

--- a/jobtracker/tracker/admin.py
+++ b/jobtracker/tracker/admin.py
@@ -1,0 +1,23 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+
+from .models import Contractor, ContractorUser
+
+
+@admin.register(ContractorUser)
+class ContractorUserAdmin(UserAdmin):
+    fieldsets = UserAdmin.fieldsets + (
+        (None, {'fields': ('contractor',)}),
+    )
+    add_fieldsets = UserAdmin.add_fieldsets + (
+        (None, {'fields': ('contractor',)}),
+    )
+    list_display = ('email', 'contractor', 'is_staff', 'is_superuser')
+    search_fields = ('email',)
+    ordering = ('email',)
+
+
+@admin.register(Contractor)
+class ContractorAdmin(admin.ModelAdmin):
+    list_display = ('email', 'material_markup')
+    search_fields = ('email',)

--- a/jobtracker/tracker/backends.py
+++ b/jobtracker/tracker/backends.py
@@ -1,0 +1,17 @@
+from django.contrib.auth.backends import ModelBackend
+from django.contrib.auth import get_user_model
+
+
+class EmailBackend(ModelBackend):
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        UserModel = get_user_model()
+        if username is None:
+            username = kwargs.get('email')
+        try:
+            user = UserModel.objects.get(email=username)
+        except UserModel.DoesNotExist:
+            return None
+        else:
+            if user.check_password(password) and self.user_can_authenticate(user):
+                return user
+        return None

--- a/jobtracker/tracker/migrations/0002_contractoruser.py
+++ b/jobtracker/tracker/migrations/0002_contractoruser.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import django.utils.timezone
+import django.contrib.auth.models
+import tracker.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0012_alter_user_first_name_max_length'),
+        ('tracker', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='contractor',
+            name='password',
+        ),
+        migrations.CreateModel(
+            name='ContractorUser',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('password', models.CharField(max_length=128, verbose_name='password')),
+                ('last_login', models.DateTimeField(blank=True, null=True, verbose_name='last login')),
+                ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
+                ('first_name', models.CharField(blank=True, max_length=150, verbose_name='first name')),
+                ('last_name', models.CharField(blank=True, max_length=150, verbose_name='last name')),
+                ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
+                ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
+                ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),
+                ('email', models.EmailField(max_length=254, unique=True)),
+                ('contractor', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='users', to='tracker.contractor')),
+                ('groups', models.ManyToManyField(blank=True, related_name='user_set', related_query_name='user', to='auth.group', verbose_name='groups')),
+                ('user_permissions', models.ManyToManyField(blank=True, related_name='user_set', related_query_name='user', to='auth.permission', verbose_name='user permissions')),
+            ],
+            options={
+                'abstract': False,
+            },
+            managers=[
+                ('objects', tracker.models.ContractorUserManager()),
+            ],
+        ),
+    ]

--- a/jobtracker/tracker/models.py
+++ b/jobtracker/tracker/models.py
@@ -1,11 +1,54 @@
 from django.db import models
+from django.contrib.auth.models import AbstractUser, BaseUserManager
 
 
 class Contractor(models.Model):
     email = models.EmailField(unique=True)
-    password = models.CharField(max_length=128)
     logo = models.CharField(max_length=255, blank=True)
     material_markup = models.DecimalField(max_digits=5, decimal_places=2, default=0)
+
+    def __str__(self) -> str:
+        return self.email
+
+
+class ContractorUserManager(BaseUserManager):
+    use_in_migrations = True
+
+    def _create_user(self, email, password, **extra_fields):
+        if not email:
+            raise ValueError("The Email must be set")
+        email = self.normalize_email(email)
+        user = self.model(email=email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_user(self, email, password=None, **extra_fields):
+        extra_fields.setdefault('is_staff', False)
+        extra_fields.setdefault('is_superuser', False)
+        return self._create_user(email, password, **extra_fields)
+
+    def create_superuser(self, email, password=None, **extra_fields):
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+
+        if extra_fields.get('is_staff') is not True:
+            raise ValueError('Superuser must have is_staff=True.')
+        if extra_fields.get('is_superuser') is not True:
+            raise ValueError('Superuser must have is_superuser=True.')
+
+        return self._create_user(email, password, **extra_fields)
+
+
+class ContractorUser(AbstractUser):
+    username = None
+    email = models.EmailField(unique=True)
+    contractor = models.ForeignKey(Contractor, related_name='users', on_delete=models.CASCADE, null=True, blank=True)
+
+    USERNAME_FIELD = 'email'
+    REQUIRED_FIELDS = []
+
+    objects = ContractorUserManager()
 
     def __str__(self) -> str:
         return self.email


### PR DESCRIPTION
## Summary
- introduce `ContractorUser` extending `AbstractUser` and link to `Contractor`
- add custom authentication backend that logs in via email
- configure project to use new user model and register it in admin

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django<6.0,>=5.0)*
- `python jobtracker/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b102c00bac8330a20c59c68da5916e