### PR TITLE
Brand admin site and register tracker models

### DIFF
--- a/jobtracker/jobtracker/settings.py
+++ b/jobtracker/jobtracker/settings.py
@@ -14,6 +14,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY', 'changeme-secret-key')
 DEBUG = os.environ.get('DEBUG', '0') == '1'
 
 ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost').split(',')
+SITE_NAME = "Squire Enterprises Job Tracker"
 
 INSTALLED_APPS = [
     'django.contrib.admin',
@@ -40,7 +41,7 @@ ROOT_URLCONF = 'jobtracker.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -84,5 +85,8 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 STATIC_ROOT = BASE_DIR / 'staticfiles'
+
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/jobtracker/jobtracker/urls.py
+++ b/jobtracker/jobtracker/urls.py
@@ -1,6 +1,11 @@
 from django.contrib import admin
 from django.urls import path
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/jobtracker/templates/admin/base_site.html
+++ b/jobtracker/templates/admin/base_site.html
@@ -1,0 +1,6 @@
+{% extends "admin/base.html" %}
+{% load static %}
+
+{% block branding %}
+<h1 id="site-name"><img src="{% static 'images/company_logo.png' %}" alt="Squire Enterprises Logo" height="40"> {{ site_header }}</h1>
+{% endblock %}

--- a/jobtracker/templates/admin/login.html
+++ b/jobtracker/templates/admin/login.html
@@ -1,0 +1,20 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block content %}
+<div id="content-main">
+    <div class="login-logo">
+        <img src="{% static 'images/company_logo.png' %}" alt="Squire Enterprises Logo" height="80">
+    </div>
+    {% if form.errors %}
+        <p class="errornote">{% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}</p>
+    {% endif %}
+    <form action="{{ form_url }}" method="post" id="login-form">{% csrf_token %}
+        {{ form.as_p }}
+        <input type="hidden" name="next" value="{{ next }}">
+        <div class="submit-row">
+            <input type="submit" value="{% translate 'Log in' %}">
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/jobtracker/tracker/admin.py
+++ b/jobtracker/tracker/admin.py
@@ -1,7 +1,37 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from django.conf import settings
 
-from .models import Contractor, ContractorUser
+from .models import (
+    Contractor,
+    ContractorUser,
+    Asset,
+    Employee,
+    Material,
+    Project,
+    JobEntry,
+    Payment,
+)
+
+
+class AssetInline(admin.TabularInline):
+    model = Asset
+    extra = 0
+
+
+class EmployeeInline(admin.TabularInline):
+    model = Employee
+    extra = 0
+
+
+class MaterialInline(admin.TabularInline):
+    model = Material
+    extra = 0
+
+
+class ProjectInline(admin.TabularInline):
+    model = Project
+    extra = 0
 
 
 @admin.register(ContractorUser)
@@ -21,3 +51,59 @@ class ContractorUserAdmin(UserAdmin):
 class ContractorAdmin(admin.ModelAdmin):
     list_display = ('email', 'material_markup')
     search_fields = ('email',)
+    fieldsets = (
+        (None, {'fields': ('email', 'logo', 'material_markup')}),
+    )
+    inlines = [AssetInline, EmployeeInline, MaterialInline, ProjectInline]
+
+
+class JobEntryInline(admin.TabularInline):
+    model = JobEntry
+    extra = 0
+
+
+class PaymentInline(admin.TabularInline):
+    model = Payment
+    extra = 0
+
+
+@admin.register(Project)
+class ProjectAdmin(admin.ModelAdmin):
+    list_display = ('name', 'contractor', 'start_date', 'end_date')
+    search_fields = ('name',)
+    inlines = [JobEntryInline, PaymentInline]
+
+
+@admin.register(Asset)
+class AssetAdmin(admin.ModelAdmin):
+    list_display = ('name', 'contractor', 'cost_rate', 'billable_rate')
+    search_fields = ('name',)
+
+
+@admin.register(Employee)
+class EmployeeAdmin(admin.ModelAdmin):
+    list_display = ('name', 'contractor', 'cost_rate', 'billable_rate')
+    search_fields = ('name',)
+
+
+@admin.register(Material)
+class MaterialAdmin(admin.ModelAdmin):
+    list_display = ('description', 'contractor', 'actual_cost')
+    search_fields = ('description',)
+
+
+@admin.register(JobEntry)
+class JobEntryAdmin(admin.ModelAdmin):
+    list_display = ('project', 'date', 'hours')
+    list_filter = ('project',)
+
+
+@admin.register(Payment)
+class PaymentAdmin(admin.ModelAdmin):
+    list_display = ('project', 'amount', 'date')
+    list_filter = ('project',)
+
+
+admin.site.site_header = settings.SITE_NAME
+admin.site.site_title = settings.SITE_NAME
+admin.site.index_title = 'Administration'

--- a/jobtracker/tracker/migrations/0003_alter_contractor_logo.py
+++ b/jobtracker/tracker/migrations/0003_alter_contractor_logo.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tracker', '0002_contractoruser'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contractor',
+            name='logo',
+            field=models.ImageField(upload_to='contractor_logos/', blank=True, null=True),
+        ),
+    ]

--- a/jobtracker/tracker/models.py
+++ b/jobtracker/tracker/models.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import AbstractUser, BaseUserManager
 
 class Contractor(models.Model):
     email = models.EmailField(unique=True)
-    logo = models.CharField(max_length=255, blank=True)
+    logo = models.ImageField(upload_to='contractor_logos/', blank=True, null=True)
     material_markup = models.DecimalField(max_digits=5, decimal_places=2, default=0)
 
     def __str__(self) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dj-database-url
 gunicorn
 psycopg2-binary
 python-dotenv
+Pillow


### PR DESCRIPTION
## Summary
- set `SITE_NAME` for custom branding and configured media paths
- override admin templates to display the company logo and site header
- register all tracker models in admin with inline editing and contractor logo uploads
- remove binary logo file to avoid PR issues

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Pillow)*
- `python jobtracker/manage.py test` *(fails: System check identified an ImageField error because Pillow is not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68b10475a508833085b5948fc440eb12