### PR TITLE
Add job entry form with auto-filled rates

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -1,0 +1,112 @@
+{% extends 'dashboard/base.html' %}
+{% block title %}Add Job Entry{% endblock %}
+{% block content %}
+<h1>Add Job Entry for {{ project.name }}</h1>
+<form method="post" id="entry-form" data-markup="{{ markup }}">
+    {% csrf_token %}
+    <div class="mb-3">
+        <label for="date" class="form-label">Date</label>
+        <input type="date" class="form-control" id="date" name="date" required>
+    </div>
+    <div class="mb-3">
+        <label for="hours" class="form-label">Hours / Quantity</label>
+        <input type="number" step="0.01" class="form-control" id="hours" name="hours" required>
+    </div>
+    <div class="mb-3">
+        <label for="asset" class="form-label">Asset</label>
+        <select class="form-select" id="asset" name="asset">
+            <option value="">---------</option>
+            {% for asset in assets %}
+                <option value="{{ asset.id }}" data-cost="{{ asset.cost_rate }}" data-billable="{{ asset.billable_rate }}">{{ asset.name }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3">
+        <label for="employee" class="form-label">Employee</label>
+        <select class="form-select" id="employee" name="employee">
+            <option value="">---------</option>
+            {% for emp in employees %}
+                <option value="{{ emp.id }}" data-cost="{{ emp.cost_rate }}" data-billable="{{ emp.billable_rate }}">{{ emp.name }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3">
+        <label for="material" class="form-label">Material</label>
+        <select class="form-select" id="material" name="material">
+            <option value="">---------</option>
+            {% for mat in materials %}
+                <option value="{{ mat.id }}" data-cost="{{ mat.actual_cost }}">{{ mat.description }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Cost Rate</label>
+        <input type="text" class="form-control" id="cost-rate" readonly>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Billable Rate</label>
+        <input type="text" class="form-control" id="billable-rate" readonly>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Cost Total</label>
+        <input type="text" class="form-control" id="cost-total" readonly>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Billable Total</label>
+        <input type="text" class="form-control" id="billable-total" readonly>
+    </div>
+    <div class="mb-3">
+        <label for="description" class="form-label">Description</label>
+        <textarea class="form-control" id="description" name="description"></textarea>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="{% url 'dashboard:project_detail' project.pk %}" class="btn btn-secondary">Cancel</a>
+</form>
+
+<script>
+(function() {
+    const assetSelect = document.getElementById('asset');
+    const employeeSelect = document.getElementById('employee');
+    const materialSelect = document.getElementById('material');
+    const hoursInput = document.getElementById('hours');
+    const costRateInput = document.getElementById('cost-rate');
+    const billableRateInput = document.getElementById('billable-rate');
+    const costTotalInput = document.getElementById('cost-total');
+    const billableTotalInput = document.getElementById('billable-total');
+    const markup = parseFloat(document.getElementById('entry-form').dataset.markup || 0);
+
+    function clearOthers(current) {
+        if (current !== assetSelect) assetSelect.value = '';
+        if (current !== employeeSelect) employeeSelect.value = '';
+        if (current !== materialSelect) materialSelect.value = '';
+    }
+
+    function updateRates(event) {
+        const select = event.target;
+        clearOthers(select);
+        const option = select.options[select.selectedIndex];
+        let cost = parseFloat(option.dataset.cost || 0);
+        let billable = parseFloat(option.dataset.billable || 0);
+        if (select === materialSelect) {
+            billable = cost * (1 + markup / 100);
+        }
+        costRateInput.value = cost ? cost.toFixed(2) : '';
+        billableRateInput.value = billable ? billable.toFixed(2) : '';
+        updateTotals();
+    }
+
+    function updateTotals() {
+        const hours = parseFloat(hoursInput.value) || 0;
+        const costRate = parseFloat(costRateInput.value) || 0;
+        const billableRate = parseFloat(billableRateInput.value) || 0;
+        costTotalInput.value = (hours * costRate).toFixed(2);
+        billableTotalInput.value = (hours * billableRate).toFixed(2);
+    }
+
+    assetSelect.addEventListener('change', updateRates);
+    employeeSelect.addEventListener('change', updateRates);
+    materialSelect.addEventListener('change', updateRates);
+    hoursInput.addEventListener('input', updateTotals);
+})();
+</script>
+{% endblock %}

--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -29,6 +29,7 @@
     </div>
 </div>
 <h2>Job Entries</h2>
+<a href="{% url 'dashboard:add_job_entry' project.pk %}" class="btn btn-primary mb-2">Add Job Entry</a>
 <table class="table table-striped mb-4">
     <thead>
         <tr>

--- a/jobtracker/dashboard/urls.py
+++ b/jobtracker/dashboard/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path('', views.contractor_summary, name='contractor_summary'),
     path('projects/', views.project_list, name='project_list'),
     path('projects/<int:pk>/', views.project_detail, name='project_detail'),
+    path('projects/<int:pk>/add-entry/', views.add_job_entry, name='add_job_entry'),
 ]


### PR DESCRIPTION
## Summary
- add view and URL for creating `JobEntry` records
- build form with contractor-filtered asset, employee, and material dropdowns
- use JavaScript to auto-fill cost and billable rates and totals
- link job entry form from project detail page

## Testing
- `python manage.py test` *(fails: tracker.Contractor.logo: (fields.E210) Cannot use ImageField because Pillow is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b108a09be08330bec337b739138ef5