### PR TITLE
Add contractor and customer reporting

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -1,0 +1,29 @@
+{% extends 'dashboard/base.html' %}
+{% block title %}Contractor Report{% endblock %}
+{% block content %}
+<h1>Contractor Report</h1>
+<a href="?export=pdf" class="btn btn-secondary mb-3">Download PDF</a>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Project</th>
+            <th>Actual Cost</th>
+            <th>Billable Total</th>
+            <th>Margin</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for p in projects %}
+        <tr>
+            <td>{{ p.name }}</td>
+            <td>${{ p.total_cost|default:0 }}</td>
+            <td>${{ p.total_billable|default:0 }}</td>
+            <td>${{ p.margin }}</td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="4">No projects.</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}
+

--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -28,5 +28,6 @@
         </div>
     </div>
 </div>
+<a href="{% url 'dashboard:contractor_report' %}" class="btn btn-secondary me-2">Contractor Report</a>
 <a href="{% url 'dashboard:project_list' %}" class="btn btn-primary">View Projects</a>
 {% endblock %}

--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -1,0 +1,29 @@
+{% extends 'dashboard/base.html' %}
+{% block title %}Customer Report{% endblock %}
+{% block content %}
+<h1>{{ project.name }} - Customer Report</h1>
+<a href="?export=pdf" class="btn btn-secondary mb-3">Download PDF</a>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Date</th>
+            <th>Description</th>
+            <th>Material</th>
+            <th>Billable Amount</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for e in entries %}
+        <tr>
+            <td>{{ e.date }}</td>
+            <td>{{ e.description }}</td>
+            <td>{% if e.material %}{{ e.material.description }}{% endif %}</td>
+            <td>${{ e.billable_amount }}</td>
+        </tr>
+    {% empty %}
+        <tr><td colspan="4">No job entries.</td></tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}
+

--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -28,6 +28,7 @@
         </div>
     </div>
 </div>
+<a href="{% url 'dashboard:customer_report' project.pk %}" class="btn btn-secondary mb-3">Customer Report</a>
 <h2>Job Entries</h2>
 <a href="{% url 'dashboard:add_job_entry' project.pk %}" class="btn btn-primary mb-2">Add Job Entry</a>
 <table class="table table-striped mb-4">

--- a/jobtracker/dashboard/urls.py
+++ b/jobtracker/dashboard/urls.py
@@ -9,4 +9,6 @@ urlpatterns = [
     path('projects/<int:pk>/', views.project_detail, name='project_detail'),
     path('projects/<int:pk>/add-entry/', views.add_job_entry, name='add_job_entry'),
     path('projects/<int:pk>/add-payment/', views.add_payment, name='add_payment'),
+    path('reports/contractor/', views.contractor_report, name='contractor_report'),
+    path('projects/<int:pk>/customer-report/', views.customer_report, name='customer_report'),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gunicorn
 psycopg2-binary
 python-dotenv
 Pillow
+xhtml2pdf


### PR DESCRIPTION
## Summary
- add PDF-capable contractor report summarizing project costs, billable totals, and margin
- add PDF-capable customer report listing billable work details without cost
- link to new reports from contractor summary and project detail pages

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement Pillow)*
- `python manage.py test` *(failed: tracker.Contractor.logo: (fields.E210) Cannot use ImageField because Pillow is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b10a92c8848330ab391e7cf315ab5e