### PR TITLE
Add media-based global logo support

### DIFF
--- a/jobtracker/jobtracker/settings.py
+++ b/jobtracker/jobtracker/settings.py
@@ -50,6 +50,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'tracker.context_processors.global_settings',
             ],
         },
     },

--- a/jobtracker/templates/admin/base_site.html
+++ b/jobtracker/templates/admin/base_site.html
@@ -1,6 +1,11 @@
 {% extends "admin/base.html" %}
-{% load static %}
+
 
 {% block branding %}
-<h1 id="site-name"><img src="{% static 'images/company_logo.png' %}" alt="Squire Enterprises Logo" height="40"> {{ site_header }}</h1>
+<h1 id="site-name">
+    {% if global_settings and global_settings.logo %}
+        <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" height="40">
+    {% endif %}
+    {{ site_header }}
+</h1>
 {% endblock %}

--- a/jobtracker/templates/admin/login.html
+++ b/jobtracker/templates/admin/login.html
@@ -1,10 +1,12 @@
 {% extends "admin/base_site.html" %}
-{% load i18n static %}
+{% load i18n %}
 
 {% block content %}
 <div id="content-main">
     <div class="login-logo">
-        <img src="{% static 'images/company_logo.png' %}" alt="Squire Enterprises Logo" height="80">
+        {% if global_settings and global_settings.logo %}
+            <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" height="80">
+        {% endif %}
     </div>
     {% if form.errors %}
         <p class="errornote">{% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}</p>

--- a/jobtracker/tracker/admin.py
+++ b/jobtracker/tracker/admin.py
@@ -3,6 +3,7 @@ from django.contrib.auth.admin import UserAdmin
 from django.conf import settings
 
 from .models import (
+    GlobalSettings,
     Contractor,
     ContractorUser,
     Asset,
@@ -55,6 +56,11 @@ class ContractorAdmin(admin.ModelAdmin):
         (None, {'fields': ('email', 'logo', 'material_markup')}),
     )
     inlines = [AssetInline, EmployeeInline, MaterialInline, ProjectInline]
+
+
+@admin.register(GlobalSettings)
+class GlobalSettingsAdmin(admin.ModelAdmin):
+    pass
 
 
 class JobEntryInline(admin.TabularInline):

--- a/jobtracker/tracker/context_processors.py
+++ b/jobtracker/tracker/context_processors.py
@@ -1,0 +1,5 @@
+from .models import GlobalSettings
+
+
+def global_settings(request):
+    return {'global_settings': GlobalSettings.objects.first()}

--- a/jobtracker/tracker/migrations/0004_globalsettings.py
+++ b/jobtracker/tracker/migrations/0004_globalsettings.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tracker', '0003_alter_contractor_logo'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='GlobalSettings',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('logo', models.ImageField(upload_to='global_logos/', blank=True, null=True)),
+            ],
+        ),
+    ]

--- a/jobtracker/tracker/models.py
+++ b/jobtracker/tracker/models.py
@@ -2,6 +2,13 @@ from django.db import models
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 
 
+class GlobalSettings(models.Model):
+    logo = models.ImageField(upload_to='global_logos/', blank=True, null=True)
+
+    def __str__(self) -> str:
+        return "Global Settings"
+
+
 class Contractor(models.Model):
     email = models.EmailField(unique=True)
     logo = models.ImageField(upload_to='contractor_logos/', blank=True, null=True)


### PR DESCRIPTION
## Summary
- Allow uploading a global Squire logo via new `GlobalSettings` model
- Provide global logo to templates through a context processor
- Replace admin templates to render uploaded global logo; contractor dashboard continues showing contractor logo

## Testing
- `pip install Pillow` *(fails: Could not find a version that satisfies the requirement Pillow)*
- `python manage.py test` *(fails: Cannot use ImageField because Pillow is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b10b90aac48330aef04bfe320e72aa