### PR TITLE
Configure Render blueprint with auto-deploy and migrations

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,9 @@ services:
     name: jobtracker
     env: python
     plan: free
+    autoDeploy: true
     buildCommand: "pip install -r requirements.txt && python jobtracker/manage.py collectstatic --no-input"
+    preDeployCommand: "python jobtracker/manage.py migrate --no-input"
     startCommand: "gunicorn jobtracker.wsgi:application"
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
## Summary
- enable auto-deploy and database migration step in Render blueprint
- keep static file collection and Gunicorn start command for the Django service

## Testing
- `python jobtracker/manage.py collectstatic --no-input`
- `python jobtracker/manage.py migrate --no-input` *(fails: Related model 'tracker.contractoruser' cannot be resolved)*
- `python jobtracker/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b10f77bcbc8330ab1a90961eace8b3