### PR TITLE
Fix admin templates and white background

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -1,37 +1,31 @@
-diff --git a/jobtracker/dashboard/templates/dashboard/base.html b/jobtracker/dashboard/templates/dashboard/base.html
-index 3df1b0224053b8128f01513d20a3a6b4cc502381..50509a968212dab962d29fae05909f758bb3b18e 100644
---- a/jobtracker/dashboard/templates/dashboard/base.html
-+++ b/jobtracker/dashboard/templates/dashboard/base.html
-@@ -1,29 +1,31 @@
- {% load static %}
- <!DOCTYPE html>
- <html lang="en">
- <head>
-     <meta charset="UTF-8">
-     <meta name="viewport" content="width=device-width, initial-scale=1">
-     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-     <link href="{% static 'css/squire.css' %}" rel="stylesheet">
-     <title>{% block title %}Dashboard{% endblock %}</title>
- </head>
- <body>
- <nav class="navbar navbar-light bg-light mb-4">
-     <div class="container-fluid">
-         {% if contractor and contractor.logo %}
-             <img src="{{ contractor.logo.url }}" alt="Contractor Logo" class="me-3 img-fluid" style="max-height:50px;">
-         {% elif global_settings and global_settings.logo %}
-             <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" class="me-3 img-fluid" style="max-height:50px;">
-+        {% else %}
-+            <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="me-3 img-fluid" style="max-height:50px;">
-         {% endif %}
-         {% if contractor %}
-             <span class="navbar-brand mb-0 h1">{{ contractor.name|default:contractor.email }}</span>
-         {% endif %}
-     </div>
- </nav>
- <div class="container">
-     {% block content %}{% endblock %}
- </div>
- <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
- </body>
- </html>
-
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{% static 'css/squire.css' %}" rel="stylesheet">
+    <title>{% block title %}Dashboard{% endblock %}</title>
+</head>
+<body>
+<nav class="navbar navbar-light bg-light mb-4">
+    <div class="container-fluid">
+        {% if contractor and contractor.logo %}
+            <img src="{{ contractor.logo.url }}" alt="Contractor Logo" class="me-3 img-fluid" style="max-height:50px;">
+        {% elif global_settings and global_settings.logo %}
+            <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" class="me-3 img-fluid" style="max-height:50px;">
+        {% else %}
+            <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="me-3 img-fluid" style="max-height:50px;">
+        {% endif %}
+        {% if contractor %}
+            <span class="navbar-brand mb-0 h1">{{ contractor.name|default:contractor.email }}</span>
+        {% endif %}
+    </div>
+</nav>
+<div class="container">
+    {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1,39 +1,39 @@
-diff --git a/jobtracker/static/css/squire.css b/jobtracker/static/css/squire.css
-index 670f3ffe33cc37af091f38e84be94305e50ed760..c42312a788dab90378016c2cb38465f883ae0666 100644
---- a/jobtracker/static/css/squire.css
-+++ b/jobtracker/static/css/squire.css
-@@ -47,25 +47,34 @@ a.button {
- 
- #branding h1,
- #branding h1 a {
-     color: #fff;
- }
- 
- a {
-     color: #003366;
-     text-decoration: none;
- }
- 
- a:hover {
-     text-decoration: underline;
- }
- 
- .login-logo {
-     text-align: center;
-     margin-bottom: 1rem;
- }
- 
- #content-main {
-     max-width: 480px;
-     margin: auto;
- }
- 
-+/* Ensure admin interface sections use light backgrounds for readability */
-+.module,
-+.module table,
-+.module table th,
-+.module table td {
-+    background-color: #fff;
-+    color: var(--body-fg);
-+}
-+
+/* Custom styles for Squire Enterprises admin and dashboard */
+
+body {
+    background-color: #fff;
+    color: #000;
+}
+
+#branding h1,
+#branding h1 a {
+    color: #fff;
+}
+
+a {
+    color: #003366;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.login-logo {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+#content-main {
+    max-width: 480px;
+    margin: auto;
+}
+
+/* Ensure admin interface sections use light backgrounds for readability */
+.module,
+.module table,
+.module table th,
+.module table td {
+    background-color: #fff;
+    color: var(--body-fg);
+}

--- a/jobtracker/templates/admin/base_site.html
+++ b/jobtracker/templates/admin/base_site.html
@@ -1,23 +1,17 @@
-diff --git a/jobtracker/templates/admin/base_site.html b/jobtracker/templates/admin/base_site.html
-index cc046caf41e30211ddef619b5afc863f61ba42ba..3a4c092916f7c6da930713eab2d1160c1ba974c1 100644
---- a/jobtracker/templates/admin/base_site.html
-+++ b/jobtracker/templates/admin/base_site.html
-@@ -1,16 +1,18 @@
- {% extends "admin/base.html" %}
- {% load static %}
- 
- {% block extrahead %}
-     {{ block.super }}
-     <link rel="stylesheet" href="{% static 'css/squire.css' %}">
- {% endblock %}
- 
- {% block branding %}
- <h1 id="site-name">
-     {% if global_settings and global_settings.logo %}
-         <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:40px;">
-+    {% else %}
-+        <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:40px;">
-     {% endif %}
-     {{ site_header }}
- </h1>
- {% endblock %}
+{% extends "admin/base.html" %}
+{% load static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'css/squire.css' %}">
+{% endblock %}
+
+{% block branding %}
+<h1 id="site-name">
+    {% if global_settings and global_settings.logo %}
+        <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:40px;">
+    {% else %}
+        <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:40px;">
+    {% endif %}
+</h1>
+{% endblock %}

--- a/jobtracker/templates/admin/login.html
+++ b/jobtracker/templates/admin/login.html
@@ -1,30 +1,24 @@
-diff --git a/jobtracker/templates/admin/login.html b/jobtracker/templates/admin/login.html
-index 02b3a27edf591c697331e329ac72d19815c50759..3e9ce4af052eda9b8ec81633fd1aa104af82989c 100644
---- a/jobtracker/templates/admin/login.html
-+++ b/jobtracker/templates/admin/login.html
-@@ -1,22 +1,24 @@
- {% extends "admin/base_site.html" %}
--{% load i18n %}
-+{% load i18n static %}
- 
- {% block content %}
- <div id="content-main">
-     <div class="login-logo">
-         {% if global_settings and global_settings.logo %}
-             <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" height="80">
-+        {% else %}
-+            <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" height="80">
-         {% endif %}
-     </div>
-     {% if form.errors %}
-         <p class="errornote">{% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}</p>
-     {% endif %}
-     <form action="{{ form_url }}" method="post" id="login-form">{% csrf_token %}
-         {{ form.as_p }}
-         <input type="hidden" name="next" value="{{ next }}">
-         <div class="submit-row">
-             <input type="submit" value="{% translate 'Log in' %}">
-         </div>
-     </form>
- </div>
- {% endblock %}
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block content %}
+<div id="content-main">
+    <div class="login-logo">
+        {% if global_settings and global_settings.logo %}
+            <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" height="80">
+        {% else %}
+            <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" height="80">
+        {% endif %}
+    </div>
+    {% if form.errors %}
+        <p class="errornote">{% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}</p>
+    {% endif %}
+    <form action="{{ form_url }}" method="post" id="login-form">{% csrf_token %}
+        {{ form.as_p }}
+        <input type="hidden" name="next" value="{{ next }}">
+        <div class="submit-row">
+            <input type="submit" value="{% translate 'Log in' %}">
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/jobtracker/templates/registration/login.html
+++ b/jobtracker/templates/registration/login.html
@@ -1,47 +1,42 @@
-diff --git a/jobtracker/templates/registration/login.html b/jobtracker/templates/registration/login.html
-index 4800d8ae70b45b49c14e61fcba38cb4311e3aded..16f089b11bc435d8c0878e68ed9e4b4b7aef9bfe 100644
---- a/jobtracker/templates/registration/login.html
-+++ b/jobtracker/templates/registration/login.html
-@@ -1,40 +1,42 @@
- {% load static %}
- <!DOCTYPE html>
- <html lang="en">
- <head>
-     <meta charset="UTF-8">
-     <meta name="viewport" content="width=device-width, initial-scale=1">
-     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-     <link href="{% static 'css/squire.css' %}" rel="stylesheet">
-     <title>Log in</title>
- </head>
- <body class="bg-light">
- <div class="container d-flex justify-content-center align-items-center" style="min-height:100vh;">
-     <div class="card p-4 shadow-sm" style="width: 100%; max-width: 360px;">
-         <div class="text-center mb-3">
-             {% if global_settings and global_settings.logo %}
-                 <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:80px;">
-+            {% else %}
-+                <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:80px;">
-             {% endif %}
-         </div>
-         {% if form.errors %}
-             <div class="alert alert-danger" role="alert">
-                 {% if form.errors|length == 1 %}
-                     Please correct the error below.
-                 {% else %}
-                     Please correct the errors below.
-                 {% endif %}
-             </div>
-         {% endif %}
-         <form method="post">
-             {% csrf_token %}
-             {{ form.as_p }}
-             <input type="hidden" name="next" value="{{ next }}">
-             <div class="d-grid">
-                 <button type="submit" class="btn btn-primary">Log in</button>
-             </div>
-         </form>
-     </div>
- </div>
- <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
- </body>
- </html>
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="{% static 'css/squire.css' %}" rel="stylesheet">
+    <title>Log in</title>
+</head>
+<body class="bg-light">
+<div class="container d-flex justify-content-center align-items-center" style="min-height:100vh;">
+    <div class="card p-4 shadow-sm" style="width: 100%; max-width: 360px;">
+        <div class="text-center mb-3">
+            {% if global_settings and global_settings.logo %}
+                <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:80px;">
+            {% else %}
+                <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:80px;">
+            {% endif %}
+        </div>
+        {% if form.errors %}
+            <div class="alert alert-danger" role="alert">
+                {% if form.errors|length == 1 %}
+                    Please correct the error below.
+                {% else %}
+                    Please correct the errors below.
+                {% endif %}
+            </div>
+        {% endif %}
+        <form method="post">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <input type="hidden" name="next" value="{{ next }}">
+            <div class="d-grid">
+                <button type="submit" class="btn btn-primary">Log in</button>
+            </div>
+        </form>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove stray text from admin templates and show logo properly
- provide logo fallback in login and dashboard templates
- lighten interface with white background styles

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e20c32948330a70156b2ea1e3ef7