### PR TITLE
Show header logo and calculate job entry totals

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -12,9 +12,9 @@
 <nav class="navbar navbar-light bg-light mb-4">
     <div class="container-fluid">
         {% if contractor and contractor.logo %}
-            <img src="{{ contractor.logo.url }}" alt="Contractor Logo" class="me-3 img-fluid" style="max-height:50px;">
+            <img src="{{ contractor.logo.url }}" onerror="this.onerror=null;this.src='{% static 'img/logo.png' %}';" alt="Contractor Logo" class="me-3 img-fluid" style="max-height:50px;">
         {% elif global_settings and global_settings.logo %}
-            <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" class="me-3 img-fluid" style="max-height:50px;">
+            <img src="{{ global_settings.logo.url }}" onerror="this.onerror=null;this.src='{% static 'img/logo.png' %}';" alt="Squire Enterprises Logo" class="me-3 img-fluid" style="max-height:50px;">
         {% else %}
             <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="me-3 img-fluid" style="max-height:50px;">
         {% endif %}

--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -50,11 +50,11 @@
         </div>
         <div class="col-12 col-md-6">
             <label class="form-label">Cost Total</label>
-            <input type="text" class="form-control" id="cost-total" readonly>
+            <input type="number" step="0.01" class="form-control" id="cost-total" name="cost_amount" readonly>
         </div>
         <div class="col-12 col-md-6">
             <label class="form-label">Billable Total</label>
-            <input type="text" class="form-control" id="billable-total" readonly>
+            <input type="number" step="0.01" class="form-control" id="billable-total" name="billable_amount" readonly>
         </div>
         <div class="col-12">
             <label for="description" class="form-label">Description</label>

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -19,6 +19,10 @@ body {
     color: var(--text-color);
 }
 
+.navbar a {
+    color: var(--primary-color) !important;
+}
+
 #header,
 .navbar {
     background-color: var(--background-color) !important;

--- a/jobtracker/templates/admin/base_site.html
+++ b/jobtracker/templates/admin/base_site.html
@@ -9,11 +9,11 @@
 {% block bodyclass %}{{ block.super }} bg-light{% endblock %}
 
 {% block branding %}
-<h1 id="site-name">
-    {% if global_settings and global_settings.logo %}
-        <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:40px;">
-    {% else %}
-        <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:40px;">
-    {% endif %}
-</h1>
+    <h1 id="site-name">
+        {% if global_settings and global_settings.logo %}
+            <img src="{{ global_settings.logo.url }}" onerror="this.onerror=null;this.src='{% static 'img/logo.png' %}';" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:40px;">
+        {% else %}
+            <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:40px;">
+        {% endif %}
+    </h1>
 {% endblock %}

--- a/jobtracker/templates/admin/login.html
+++ b/jobtracker/templates/admin/login.html
@@ -6,7 +6,7 @@
     <div class="card p-4 shadow-sm" style="width:100%; max-width:360px;">
         <div class="text-center mb-3">
             {% if global_settings and global_settings.logo %}
-                <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:80px;">
+                <img src="{{ global_settings.logo.url }}" onerror="this.onerror=null;this.src='{% static 'img/logo.png' %}';" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:80px;">
             {% else %}
                 <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:80px;">
             {% endif %}

--- a/jobtracker/templates/registration/login.html
+++ b/jobtracker/templates/registration/login.html
@@ -13,7 +13,7 @@
     <div class="card p-4 shadow-sm" style="width: 100%; max-width: 360px;">
         <div class="text-center mb-3">
             {% if global_settings and global_settings.logo %}
-                <img src="{{ global_settings.logo.url }}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:80px;">
+                <img src="{{ global_settings.logo.url }}" onerror="this.onerror=null;this.src='{% static 'img/logo.png' %}';" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:80px;">
             {% else %}
                 <img src="{% static 'img/logo.png' %}" alt="Squire Enterprises Logo" class="img-fluid" style="max-height:80px;">
             {% endif %}


### PR DESCRIPTION
## Summary
- Fallback to bundled logo image if a custom logo fails to load on dashboard and auth templates
- Style navigation links so they remain visible on light backgrounds
- Make job entry cost and billable totals read-only numeric fields that auto-update

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e79f6e3483308e8e998ed0c27c0b