### PR TITLE
Compute job entry cost and billable totals automatically

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -41,14 +41,6 @@
             </select>
         </div>
         <div class="col-12 col-md-6">
-            <label class="form-label">Cost Rate</label>
-            <input type="text" class="form-control" id="cost-rate" readonly>
-        </div>
-        <div class="col-12 col-md-6">
-            <label class="form-label">Billable Rate</label>
-            <input type="text" class="form-control" id="billable-rate" readonly>
-        </div>
-        <div class="col-12 col-md-6">
             <label class="form-label">Cost Total</label>
             <input type="number" step="0.01" class="form-control" id="cost-total" name="cost_amount" readonly>
         </div>
@@ -73,13 +65,10 @@
     const employeeSelect = document.getElementById('employee');
     const materialSelect = document.getElementById('material');
     const hoursInput = document.getElementById('hours');
-    const costRateInput = document.getElementById('cost-rate');
-    const billableRateInput = document.getElementById('billable-rate');
     const costTotalInput = document.getElementById('cost-total');
     const billableTotalInput = document.getElementById('billable-total');
     const markup = parseFloat(document.getElementById('entry-form').dataset.markup || 0);
-
-    function updateRates() {
+    function updateTotals() {
         const assetOption = assetSelect.options[assetSelect.selectedIndex];
         const employeeOption = employeeSelect.options[employeeSelect.selectedIndex];
         const materialOption = materialSelect.options[materialSelect.selectedIndex];
@@ -91,26 +80,20 @@
         const materialCost = parseFloat(materialOption?.dataset.cost || 0);
         const materialBillable = materialCost * (1 + markup / 100);
 
-        const costRate = assetCost + employeeCost + materialCost;
-        const billableRate = assetBillable + employeeBillable + materialBillable;
-
-        costRateInput.value = costRate ? costRate.toFixed(2) : '';
-        billableRateInput.value = billableRate ? billableRate.toFixed(2) : '';
-        updateTotals();
-    }
-
-    function updateTotals() {
         const hours = parseFloat(hoursInput.value) || 0;
-        const costRate = parseFloat(costRateInput.value) || 0;
-        const billableRate = parseFloat(billableRateInput.value) || 0;
-        costTotalInput.value = (hours * costRate).toFixed(2);
-        billableTotalInput.value = (hours * billableRate).toFixed(2);
+
+        const costTotal = assetCost + employeeCost * hours + materialCost;
+        const billableTotal = assetBillable + employeeBillable * hours + materialBillable;
+
+        costTotalInput.value = costTotal ? costTotal.toFixed(2) : '';
+        billableTotalInput.value = billableTotal ? billableTotal.toFixed(2) : '';
     }
 
-    assetSelect.addEventListener('change', updateRates);
-    employeeSelect.addEventListener('change', updateRates);
-    materialSelect.addEventListener('change', updateRates);
+    assetSelect.addEventListener('change', updateTotals);
+    employeeSelect.addEventListener('change', updateTotals);
+    materialSelect.addEventListener('change', updateTotals);
     hoursInput.addEventListener('input', updateTotals);
+    updateTotals();
 })();
 </script>
 {% endblock %}

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -143,15 +143,15 @@ def add_job_entry(request, pk):
         cost_amount = Decimal("0")
         billable_amount = Decimal("0")
         if asset:
-            cost_amount += asset.cost_rate * hours
-            billable_amount += asset.billable_rate * hours
+            cost_amount += asset.cost_rate
+            billable_amount += asset.billable_rate
         if employee:
             cost_amount += employee.cost_rate * hours
             billable_amount += employee.billable_rate * hours
         if material:
-            cost_amount += material.actual_cost * hours
-            billable_amount += (
-                material.actual_cost * (1 + contractor.material_markup / Decimal("100")) * hours
+            cost_amount += material.actual_cost
+            billable_amount += material.actual_cost * (
+                1 + contractor.material_markup / Decimal("100")
             )
 
         JobEntry.objects.create(

--- a/jobtracker/tracker/admin.py
+++ b/jobtracker/tracker/admin.py
@@ -102,8 +102,20 @@ class MaterialAdmin(admin.ModelAdmin):
 
 @admin.register(JobEntry)
 class JobEntryAdmin(admin.ModelAdmin):
-    list_display = ('project', 'date', 'hours')
+    list_display = ('project', 'date', 'hours', 'cost_amount', 'billable_amount')
     list_filter = ('project',)
+    fields = (
+        'project',
+        'date',
+        'hours',
+        'asset',
+        'employee',
+        'material',
+        'description',
+        'cost_amount',
+        'billable_amount',
+    )
+    readonly_fields = ('cost_amount', 'billable_amount')
 
 
 @admin.register(Payment)


### PR DESCRIPTION
## Summary
- Remove manual cost and billable inputs from job entry form and show calculated totals instead
- Calculate job entry totals as asset cost + employee cost × hours + material cost, using markup for billable material
- Update backend to derive cost and billable amounts from selected asset, employee, material, and hours
- Display read-only cost and billable totals in the admin job entry form

## Testing
- `python jobtracker/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea9fb7d08330afbe002805cc59b3