### PR TITLE
Fix contractor login redirect to dashboard

### DIFF
--- a/jobtracker/jobtracker/settings.py
+++ b/jobtracker/jobtracker/settings.py
@@ -101,3 +101,4 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+LOGIN_REDIRECT_URL = '/'

--- a/jobtracker/tracker/tests.py
+++ b/jobtracker/tracker/tests.py
@@ -1,7 +1,18 @@
 from decimal import Decimal
+
 from django.test import TestCase, RequestFactory
 from django.contrib.admin.sites import AdminSite
-from tracker.models import Contractor, Project, Asset, Employee, Material, JobEntry, ContractorUser
+from django.urls import reverse
+
+from tracker.models import (
+    Contractor,
+    Project,
+    Asset,
+    Employee,
+    Material,
+    JobEntry,
+    ContractorUser,
+)
 from tracker.forms import ContractorForm
 from tracker.admin import ContractorAdmin
 
@@ -61,4 +72,20 @@ class ContractorAdminTests(TestCase):
         user = ContractorUser.objects.get(contractor=obj)
         self.assertEqual(user.email, "contractor@example.com")
         self.assertTrue(user.check_password("secret123"))
+
+
+class LoginRedirectTests(TestCase):
+    def test_login_redirects_to_root(self):
+        contractor = Contractor.objects.create(
+            name="Example Contractor", email="user@example.com"
+        )
+        ContractorUser.objects.create_user(
+            email="user@example.com", password="secret", contractor=contractor
+        )
+        response = self.client.post(
+            reverse("login"),
+            {"username": "user@example.com", "password": "secret"},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/")
 


### PR DESCRIPTION
## Summary
- redirect logged-in contractors to the dashboard instead of `/accounts/profile`
- test login redirect behaviour

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b20c5b949883309ae2a67ee0bf6c4d