### PR TITLE
Fix contractor logo missing on dashboard

### DIFF
--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -1,3 +1,32 @@
 from django.test import TestCase
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
 
-# Create your tests here.
+from tracker.models import Contractor, ContractorUser
+
+
+class DashboardLogoTests(TestCase):
+    def test_dashboard_displays_contractor_logo(self):
+        """The contractor's logo should appear on the dashboard navbar."""
+
+        logo_content = (
+            b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00"
+            b"\x00\x00\x00\xff\xff\xff!\xf9\x04\x01\n\x00\x01\x00,"
+            b"\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"
+        )
+        logo_file = SimpleUploadedFile("logo.gif", logo_content, content_type="image/gif")
+
+        contractor = Contractor.objects.create(
+            name="Test Contractor", email="user@example.com", logo=logo_file
+        )
+        ContractorUser.objects.create_user(
+            email="user@example.com", password="secret", contractor=contractor
+        )
+
+        self.client.post(
+            reverse("login"), {"username": "user@example.com", "password": "secret"}
+        )
+        response = self.client.get(reverse("dashboard:contractor_summary"))
+
+        self.assertContains(response, contractor.logo.url)
+

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -62,7 +62,6 @@ def contractor_summary(request):
         request,
         'dashboard/contractor_summary.html',
         {
-            'contractor': contractor,
             'projects': projects,
             'overall_billable': overall_billable,
             'overall_payments': overall_payments,
@@ -86,7 +85,6 @@ def project_list(request):
         request,
         'dashboard/project_list.html',
         {
-            'contractor': contractor,
             'projects': projects,
         },
     )
@@ -107,7 +105,6 @@ def project_detail(request, pk):
         request,
         'dashboard/project_detail.html',
         {
-            'contractor': contractor,
             'project': project,
             'job_entries': job_entries,
             'payments': payments,
@@ -171,7 +168,6 @@ def add_job_entry(request, pk):
         request,
         "dashboard/jobentry_form.html",
         {
-            "contractor": contractor,
             "project": project,
             "assets": assets,
             "employees": employees,
@@ -199,7 +195,6 @@ def add_payment(request, pk):
         request,
         "dashboard/payment_form.html",
         {
-            "contractor": contractor,
             "project": project,
         },
     )

--- a/jobtracker/jobtracker/settings.py
+++ b/jobtracker/jobtracker/settings.py
@@ -59,6 +59,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'tracker.context_processors.global_settings',
+                'tracker.context_processors.contractor',
             ],
         },
     },

--- a/jobtracker/tracker/context_processors.py
+++ b/jobtracker/tracker/context_processors.py
@@ -22,3 +22,16 @@ def global_settings(request):
         settings_obj = None
 
     return {"global_settings": settings_obj}
+
+
+def contractor(request):
+    """Provide the logged-in contractor for templates.
+
+    Including this context processor ensures templates such as the dashboard
+    base layout can always access ``contractor`` without each view needing to
+    supply it explicitly.
+    """
+
+    user = getattr(request, "user", None)
+    contract = getattr(user, "contractor", None) if getattr(user, "is_authenticated", False) else None
+    return {"contractor": contract}


### PR DESCRIPTION
## Summary
- ensure logged in contractor is always available to templates via new context processor
- simplify dashboard views to rely on shared contractor context
- add regression test confirming contractor logo appears on dashboard

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b20e5a614c8330b84b460e92738826