### PR TITLE
Show dashboard link and contractor logo in reports

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -8,7 +8,7 @@
 </div>
 {% endif %}
 <h1 class="text-center">Contractor Report</h1>
-<a href="?export=pdf" class="btn btn-secondary mb-3">Download PDF</a>
+<a href="?export=pdf" class="btn btn-secondary mb-3 d-print-none">Download PDF</a>
 <div class="table-responsive">
     <table class="table table-bordered">
         <thead class="table-light">

--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -8,7 +8,7 @@
 </div>
 {% endif %}
 <h1 class="text-center">Invoice - {{ project.name }}</h1>
-<a href="?export=pdf" class="btn btn-secondary mb-3">Download PDF</a>
+<a href="?export=pdf" class="btn btn-secondary mb-3 d-print-none">Download PDF</a>
 <div class="table-responsive">
     <table class="table table-bordered">
         <thead class="table-light">

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -213,9 +213,15 @@ def contractor_report(request):
     )
     for p in projects:
         p.margin = (p.total_billable or 0) - (p.total_cost or 0)
-    logo_url = request.build_absolute_uri(contractor.logo.url) if contractor and contractor.logo else None
-    context = {"contractor": contractor, "projects": projects, "contractor_logo_url": logo_url, "report": True}
-    if request.GET.get("export") == "pdf":
+    logo_url = contractor.logo.url if contractor and contractor.logo else None
+    export_pdf = request.GET.get("export") == "pdf"
+    context = {
+        "contractor": contractor,
+        "projects": projects,
+        "contractor_logo_url": logo_url,
+        "report": export_pdf,
+    }
+    if export_pdf:
         pdf = _render_pdf("dashboard/contractor_report.html", context)
         if pdf:
             pdf["Content-Disposition"] = "attachment; filename=contractor_report.pdf"
@@ -231,16 +237,17 @@ def customer_report(request, pk):
     project = get_object_or_404(Project, pk=pk, contractor=contractor)
     entries = project.job_entries.select_related("asset", "employee", "material").all()
     total = entries.aggregate(total=Sum("billable_amount"))["total"] or 0
-    logo_url = request.build_absolute_uri(contractor.logo.url) if contractor and contractor.logo else None
+    logo_url = contractor.logo.url if contractor and contractor.logo else None
+    export_pdf = request.GET.get("export") == "pdf"
     context = {
         "contractor": contractor,
         "project": project,
         "entries": entries,
         "total": total,
         "contractor_logo_url": logo_url,
-        "report": True,
+        "report": export_pdf,
     }
-    if request.GET.get("export") == "pdf":
+    if export_pdf:
         pdf = _render_pdf("dashboard/customer_report.html", context)
         if pdf:
             pdf["Content-Disposition"] = "attachment; filename=customer_report.pdf"


### PR DESCRIPTION
## Summary
- Show Dashboard navigation on contractor and customer reports when viewing in browser
- Include contractor-specific logos in generated report PDFs
- Hide the PDF download link when printing

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b224ba6db08330b107e517c6201f28