### PR TITLE
Display profit and margin percentage on contractor report

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -16,6 +16,7 @@
                 <th style="text-align:left;">Project</th>
                 <th style="text-align:right;">Actual Cost</th>
                 <th style="text-align:right;">Billable Total</th>
+                <th style="text-align:right;">Profit</th>
                 <th style="text-align:right;">Margin</th>
             </tr>
         </thead>
@@ -25,10 +26,11 @@
                 <td style="text-align:left;">{{ p.name }}</td>
                 <td style="text-align:right;">${{ p.total_cost|default:0 }}</td>
                 <td style="text-align:right;">${{ p.total_billable|default:0 }}</td>
-                <td style="text-align:right;">${{ p.margin }}</td>
+                <td style="text-align:right;">${{ p.profit|default:0 }}</td>
+                <td style="text-align:right;">{{ p.margin|floatformat:2 }}%</td>
             </tr>
         {% empty %}
-            <tr><td colspan="4">No projects.</td></tr>
+            <tr><td colspan="5">No projects.</td></tr>
         {% endfor %}
         </tbody>
     </table>

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -212,7 +212,12 @@ def contractor_report(request):
         total_billable=Sum("job_entries__billable_amount"),
     )
     for p in projects:
-        p.margin = (p.total_billable or 0) - (p.total_cost or 0)
+        total_billable = p.total_billable or Decimal("0")
+        total_cost = p.total_cost or Decimal("0")
+        p.profit = total_billable - total_cost
+        p.margin = (
+            (p.profit / total_billable) * Decimal("100") if total_billable else Decimal("0")
+        )
     logo_url = contractor.logo.url if contractor and contractor.logo else None
     export_pdf = request.GET.get("export") == "pdf"
     context = {


### PR DESCRIPTION
## Summary
- show profit in dollars and margin as a percentage on contractor report
- add Profit column to contractor report table

## Testing
- `python jobtracker/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b22a5ecc9c83308f064538563fd977