### PR TITLE
Persist contractor logo after upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .env
 venv/
 staticfiles/
+jobtracker/media/

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -55,3 +55,31 @@ class DashboardLogoTests(TestCase):
 
         self.assertContains(response, static("img/logo.png"))
 
+    def test_logo_persists_after_upload(self):
+        """A newly uploaded logo remains visible after a refresh."""
+
+        contractor = Contractor.objects.create(
+            name="Test Contractor", email="user@example.com"
+        )
+        ContractorUser.objects.create_user(
+            email="user@example.com", password="secret", contractor=contractor
+        )
+
+        self.client.post(
+            reverse("login"), {"username": "user@example.com", "password": "secret"}
+        )
+
+        logo_content = (
+            b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00"
+            b"\x00\x00\x00\xff\xff\xff!\xf9\x04\x01\n\x00\x01\x00,"
+            b"\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"
+        )
+        logo_file = SimpleUploadedFile("logo.gif", logo_content, content_type="image/gif")
+
+        contractor.logo = logo_file
+        contractor.save()
+
+        response = self.client.get(reverse("dashboard:contractor_summary"))
+
+        self.assertContains(response, contractor.logo.url)
+

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -67,7 +67,7 @@ def contractor_summary(request):
             'overall_payments': overall_payments,
             'outstanding': outstanding,
             'contractor': contractor,
-            'contractor_logo_url': request.build_absolute_uri(contractor.logo.url) if contractor.logo else None,
+            'contractor_logo_url': contractor.logo.url if contractor.logo else None,
         },
     )
 

--- a/jobtracker/tracker/context_processors.py
+++ b/jobtracker/tracker/context_processors.py
@@ -38,9 +38,5 @@ def contractor(request):
         if getattr(user, "is_authenticated", False)
         else None
     )
-    logo_url = (
-        request.build_absolute_uri(contract.logo.url)
-        if contract and contract.logo
-        else None
-    )
+    logo_url = contract.logo.url if contract and contract.logo else None
     return {"contractor": contract, "contractor_logo_url": logo_url}


### PR DESCRIPTION
## Summary
- Use relative URL for contractor logos to prevent disappearing images
- Adjust dashboard view and context processor to use stored logo URLs
- Add regression test ensuring uploaded logos persist after refresh
- Ignore media directory in git

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b22c18cf3883308d82c4751dd832cc