### PR TITLE
Persist contractor logos across deployments

### DIFF
--- a/jobtracker/jobtracker/settings.py
+++ b/jobtracker/jobtracker/settings.py
@@ -99,7 +99,11 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'
 STATICFILES_DIRS = [BASE_DIR / 'static']
 
 MEDIA_URL = '/media/'
-MEDIA_ROOT = BASE_DIR / 'media'
+# Allow MEDIA_ROOT to be overridden via environment variable so that
+# user-uploaded files (such as contractor logos) can be stored on a
+# persistent disk when deployed to Render. Falling back to the project
+# directory keeps local development behaviour unchanged.
+MEDIA_ROOT = Path(os.environ.get('MEDIA_ROOT', BASE_DIR / 'media'))
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 LOGIN_REDIRECT_URL = '/'

--- a/render.yaml
+++ b/render.yaml
@@ -10,6 +10,9 @@ services:
     # change into that folder before loading the WSGI module so Django can find
     # its settings.
     startCommand: "gunicorn --chdir jobtracker jobtracker.wsgi:application"
+    disk:
+      name: media
+      mountPath: /var/media
     envVars:
       - key: DATABASE_URL
         fromDatabase:
@@ -23,6 +26,11 @@ services:
         value: ".onrender.com,localhost"
       - key: CSRF_TRUSTED_ORIGINS
         value: "https://*.onrender.com"
+      - key: MEDIA_ROOT
+        value: /var/media
 databases:
   - name: jobtracker-db
     plan: free
+disks:
+  - name: media
+    sizeGB: 1


### PR DESCRIPTION
## Summary
- allow MEDIA_ROOT to be overridden via environment variable for storing uploaded files on a persistent disk
- mount a Render disk and set MEDIA_ROOT so contractor logos survive redeploys

## Testing
- `python jobtracker/manage.py test dashboard tracker`


------
https://chatgpt.com/codex/tasks/task_e_68b2483fa48883308830ebd69a8b4ffd