### PR TITLE
Stream PDF generation to reduce memory usage

### DIFF
--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from io import BytesIO
 import os
 
 from django.conf import settings
@@ -37,13 +36,11 @@ def _render_pdf(template_src, context):
         return None
     template = get_template(template_src)
     html = template.render(context)
-    result = BytesIO()
-    pdf = pisa.pisaDocument(
-        BytesIO(html.encode("UTF-8")), result, link_callback=link_callback
-    )
+    response = HttpResponse(content_type="application/pdf")
+    pdf = pisa.CreatePDF(html, dest=response, link_callback=link_callback)
     if pdf.err:
         return None
-    return HttpResponse(result.getvalue(), content_type="application/pdf")
+    return response
 
 
 @login_required


### PR DESCRIPTION
## Summary
- stream PDF output directly to response to avoid buffering in memory
- remove unused BytesIO import

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b24e9e4ac48330a15f0b8df6a2d1b8