### PR TITLE
Avoid xhtml2pdf CSS parse errors

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% if not report %}
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    {% endif %}
     <link href="{% static 'css/squire.css' %}" rel="stylesheet">
     <title>{% block title %}Dashboard{% endblock %}</title>
 </head>
@@ -27,6 +29,8 @@
     {% endif %}
     {% block content %}{% endblock %}
 </div>
+{% if not report %}
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% endif %}
 </body>
 </html>

--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -8,7 +8,9 @@
 </div>
 {% endif %}
 <h1 class="text-center">Contractor Report</h1>
+{% if not report %}
 <a href="?export=pdf" class="btn btn-secondary mb-3 d-print-none">Download PDF</a>
+{% endif %}
 <div class="table-responsive">
     <table class="table table-bordered">
         <thead class="table-light">

--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -9,7 +9,9 @@
   <h2>{{ contractor.name|default:contractor.email }}</h2>
 </div>
 <h1 class="text-center">Summary of Work - {{ project.name }}</h1>
+{% if not report %}
 <a href="?export=pdf" class="btn btn-secondary mb-3 d-print-none">Download PDF</a>
+{% endif %}
 <div class="table-responsive">
     <table class="table table-bordered">
         <thead class="table-light">

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -62,3 +62,41 @@ a:hover {
     background-color: #fff;
     color: var(--text-color);
 }
+
+/* Minimal utilities for PDF rendering when Bootstrap is unavailable */
+.text-center {
+    text-align: center;
+}
+
+.mb-3 {
+    margin-bottom: 1rem;
+}
+
+.img-fluid {
+    max-width: 100%;
+    height: auto;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    border: 1px solid #dee2e6;
+    padding: 0.5rem;
+}
+
+.table-bordered {
+    border: 1px solid #dee2e6;
+}
+
+.table-light th {
+    background-color: #f8f9fa;
+}
+
+.table-responsive {
+    width: 100%;
+    overflow-x: auto;
+}


### PR DESCRIPTION
## Summary
- Avoid loading Bootstrap assets when rendering PDF reports to prevent xhtml2pdf CSS parse errors
- Hide the PDF download button during PDF generation
- Add minimal CSS utilities so reports render without Bootstrap

## Testing
- ⚠️ `python -m pip install -r requirements.txt` *(failed: Could not connect to proxy to download Django)*

------
https://chatgpt.com/codex/tasks/task_e_68b25562ca088330b17a9013d0690c23