### PR TITLE
Enable job entry editing and material quantity pricing

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/jobentry_edit_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_edit_form.html
@@ -1,0 +1,54 @@
+{% extends 'dashboard/base.html' %}
+{% block title %}Edit Job Entry{% endblock %}
+{% block content %}
+<h1>Edit Job Entry</h1>
+<form method="post">
+    {% csrf_token %}
+    <div class="row g-3 mb-3">
+        <div class="col-12 col-md-6">
+            <label for="date" class="form-label">Date</label>
+            <input type="date" class="form-control" id="date" name="date" value="{{ entry.date }}" required>
+        </div>
+    </div>
+    <div class="row g-3 mb-3">
+        <div class="col-md-2">
+            <label for="hours" class="form-label">Hours / Qty</label>
+            <input type="number" step="0.01" class="form-control" id="hours" name="hours" value="{{ entry.hours }}">
+        </div>
+        <div class="col-md-3">
+            <label for="asset" class="form-label">Asset</label>
+            <select class="form-select" id="asset" name="asset">
+                <option value="">---------</option>
+                {% for asset in assets %}
+                <option value="{{ asset.id }}" {% if entry.asset_id == asset.id %}selected{% endif %}>{{ asset.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-3">
+            <label for="employee" class="form-label">Employee</label>
+            <select class="form-select" id="employee" name="employee">
+                <option value="">---------</option>
+                {% for emp in employees %}
+                <option value="{{ emp.id }}" {% if entry.employee_id == emp.id %}selected{% endif %}>{{ emp.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-4">
+            <label for="material_description" class="form-label">Material Description</label>
+            <input type="text" class="form-control" id="material_description" name="material_description" value="{{ entry.material_description }}">
+        </div>
+    </div>
+    <div class="row g-3 mb-3">
+        <div class="col-md-4">
+            <label for="material_cost" class="form-label">Material Cost</label>
+            <input type="number" step="0.01" class="form-control" id="material_cost" name="material_cost" value="{{ entry.material_cost|default_if_none:'' }}">
+        </div>
+        <div class="col-md-8">
+            <label for="description" class="form-label">Description</label>
+            <input type="text" class="form-control" id="description" name="description" value="{{ entry.description }}">
+        </div>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="{% url 'dashboard:project_detail' entry.project.pk %}" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -36,19 +36,33 @@
         <thead>
             <tr>
                 <th>Date</th>
-                <th>Description</th>
+                <th>Hours / Qty</th>
+                <th>Asset</th>
+                <th>Employee</th>
+                <th>Material Description</th>
+                <th>Material Cost</th>
+                <th>Cost Amount</th>
                 <th>Billable Amount</th>
+                <th>Description</th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
         {% for entry in job_entries %}
             <tr>
                 <td>{{ entry.date }}</td>
-                <td>{{ entry.description }}</td>
+                <td>{{ entry.hours }}</td>
+                <td>{{ entry.asset }}</td>
+                <td>{{ entry.employee }}</td>
+                <td>{{ entry.material_description }}</td>
+                <td>{% if entry.material_cost %}${{ entry.material_cost }}{% endif %}</td>
+                <td>${{ entry.cost_amount }}</td>
                 <td>${{ entry.billable_amount }}</td>
+                <td>{{ entry.description }}</td>
+                <td><a href="{% url 'dashboard:edit_job_entry' entry.pk %}" class="btn btn-sm btn-secondary">Edit</a></td>
             </tr>
         {% empty %}
-            <tr><td colspan="3">No job entries.</td></tr>
+            <tr><td colspan="10">No job entries.</td></tr>
         {% endfor %}
         </tbody>
     </table>

--- a/jobtracker/dashboard/urls.py
+++ b/jobtracker/dashboard/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('projects/', views.project_list, name='project_list'),
     path('projects/<int:pk>/', views.project_detail, name='project_detail'),
     path('projects/<int:pk>/add-entry/', views.add_job_entry, name='add_job_entry'),
+    path('entries/<int:pk>/edit/', views.edit_job_entry, name='edit_job_entry'),
     path('projects/<int:pk>/add-payment/', views.add_payment, name='add_payment'),
     path('reports/contractor/', views.contractor_report, name='contractor_report'),
     path('projects/<int:pk>/customer-report/', views.customer_report, name='customer_report'),

--- a/jobtracker/tracker/models.py
+++ b/jobtracker/tracker/models.py
@@ -168,8 +168,9 @@ class JobEntry(models.Model):
             self.cost_amount += self.employee.cost_rate * self.hours
             self.billable_amount += self.employee.billable_rate * self.hours
         if self.material_cost:
-            self.cost_amount += self.material_cost
-            self.billable_amount += self.material_cost * (
+            material_total = self.material_cost * self.hours
+            self.cost_amount += material_total
+            self.billable_amount += material_total * (
                 1 + contractor.material_markup / Decimal("100")
             )
         super().save(*args, **kwargs)

--- a/jobtracker/tracker/tests.py
+++ b/jobtracker/tracker/tests.py
@@ -17,7 +17,7 @@ from tracker.admin import ContractorAdmin
 
 
 class JobEntryCalculationTests(TestCase):
-    def test_asset_rates_multiply_by_hours(self):
+    def test_rates_and_material_cost_multiply_by_hours(self):
         contractor = Contractor.objects.create(
             name="Test Contractor", email="contractor@example.com", material_markup=Decimal("25")
         )
@@ -46,8 +46,8 @@ class JobEntryCalculationTests(TestCase):
             material_cost=Decimal("50"),
             description="Test entry",
         )
-        self.assertEqual(entry.cost_amount, Decimal("200"))
-        self.assertEqual(entry.billable_amount, Decimal("287.50"))
+        self.assertEqual(entry.cost_amount, Decimal("400"))
+        self.assertEqual(entry.billable_amount, Decimal("537.50"))
 
 
 class ContractorAdminTests(TestCase):


### PR DESCRIPTION
## Summary
- multiply material cost by quantity and apply contractor markup
- display full job entry details and allow editing from project dashboard

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b262b491b883308c80d2e240329d9c