### PR TITLE
fix: prevent column compression in customer PDF

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -13,7 +13,7 @@
 <a href="?export=pdf" class="btn btn-secondary mb-3 d-print-none">Download PDF</a>
 {% endif %}
 <div class="table-responsive">
-    <table class="table table-bordered" style="width:100%; table-layout:fixed;">
+    <table class="table table-bordered" style="width:100%;">
         <thead class="table-light">
             <tr>
                 <th style="text-align:left; width:12%;">Date</th>


### PR DESCRIPTION
## Summary
- fix customer report table to use auto layout so columns expand

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b267ac852c83308704faa6da4e8b2e