### PR TITLE
Move contractor summary report to project list and filter open projects

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -34,7 +34,5 @@
     </div>
 
  </div>
-<a href="{% url 'dashboard:contractor_report' %}" class="btn btn-secondary me-2">Contractor Summary Report</a>
-<a href="{% url 'dashboard:project_list' %}" class="btn btn-secondary me-2">Customer Reports</a>
 <a href="{% url 'dashboard:project_list' %}" class="btn btn-primary">View Projects</a>
 {% endblock %}

--- a/jobtracker/dashboard/templates/dashboard/project_list.html
+++ b/jobtracker/dashboard/templates/dashboard/project_list.html
@@ -2,6 +2,7 @@
 {% block title %}Projects{% endblock %}
 {% block content %}
 <h1>Projects</h1>
+<a href="{% url 'dashboard:contractor_report' %}" class="btn btn-secondary mb-3">Contractor Summary Report</a>
 <div class="table-responsive">
     <table class="table table-striped">
         <thead>

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -192,3 +192,27 @@ class ContractorJobReportTests(TestCase):
         self.assertContains(response, "$50")
         self.assertContains(response, "$20")
         self.assertContains(response, "40.00%")
+
+
+class ReportButtonPlacementTests(TestCase):
+    def setUp(self):
+        self.contractor = Contractor.objects.create(
+            name="Test Contractor", email="user@example.com"
+        )
+        ContractorUser.objects.create_user(
+            email="user@example.com", password="secret", contractor=self.contractor
+        )
+        self.client.post(
+            reverse("login"), {"username": "user@example.com", "password": "secret"}
+        )
+
+    def test_contractor_summary_shows_only_view_projects_button(self):
+        response = self.client.get(reverse("dashboard:contractor_summary"))
+        self.assertContains(response, "View Projects")
+        self.assertNotContains(response, "Contractor Summary Report")
+        self.assertNotContains(response, "Customer Reports")
+
+    def test_project_list_shows_contractor_summary_report_button(self):
+        self.contractor.projects.create(name="Proj", start_date="2024-01-01")
+        response = self.client.get(reverse("dashboard:project_list"))
+        self.assertContains(response, "Contractor Summary Report")

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -51,7 +51,7 @@ def contractor_summary(request):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    projects = contractor.projects.all().annotate(
+    projects = contractor.projects.filter(end_date__isnull=True).annotate(
         total_billable=Sum('job_entries__billable_amount'),
         total_payments=Sum('payments__amount'),
     )
@@ -77,7 +77,7 @@ def project_list(request):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    projects = contractor.projects.all().annotate(
+    projects = contractor.projects.filter(end_date__isnull=True).annotate(
         total_billable=Sum('job_entries__billable_amount'),
         total_payments=Sum('payments__amount'),
     )


### PR DESCRIPTION
## Summary
- Only show "View Projects" on contractor dashboard
- Add contractor summary report link on project list page
- Ignore closed projects when summarizing payments and billable totals
- Test button placement on dashboard and project list

## Testing
- `python jobtracker/manage.py test dashboard`

------
https://chatgpt.com/codex/tasks/task_e_68b26d8e03208330a1d73fd3e573d411