### PR TITLE
Add Job Entry shortcut to contractor dashboard

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -35,4 +35,7 @@
 
  </div>
 <a href="{% url 'dashboard:project_list' %}" class="btn btn-primary">View Projects</a>
+{% if first_project %}
+<a href="{% url 'dashboard:add_job_entry' first_project.pk %}" class="btn btn-secondary ms-2">Add Job Entry</a>
+{% endif %}
 {% endblock %}

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -206,11 +206,17 @@ class ReportButtonPlacementTests(TestCase):
             reverse("login"), {"username": "user@example.com", "password": "secret"}
         )
 
-    def test_contractor_summary_shows_only_view_projects_button(self):
+    def test_contractor_summary_buttons_without_projects(self):
         response = self.client.get(reverse("dashboard:contractor_summary"))
         self.assertContains(response, "View Projects")
         self.assertNotContains(response, "Contractor Summary Report")
         self.assertNotContains(response, "Customer Reports")
+        self.assertNotContains(response, "Add Job Entry")
+
+    def test_contractor_summary_shows_job_entry_button_with_project(self):
+        self.contractor.projects.create(name="Proj", start_date="2024-01-01")
+        response = self.client.get(reverse("dashboard:contractor_summary"))
+        self.assertContains(response, "Add Job Entry")
 
     def test_project_list_shows_contractor_summary_report_button(self):
         self.contractor.projects.create(name="Proj", start_date="2024-01-01")

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -52,6 +52,7 @@ def contractor_summary(request):
     if contractor is None:
         return redirect("login")
     projects = contractor.projects.filter(end_date__isnull=True)
+    first_project = projects.first()
     overall_billable = (
         JobEntry.objects.filter(project__contractor=contractor, project__end_date__isnull=True)
         .aggregate(total=Sum("billable_amount"))
@@ -70,6 +71,7 @@ def contractor_summary(request):
         'dashboard/contractor_summary.html',
         {
             'projects': projects,
+            'first_project': first_project,
             'overall_billable': overall_billable,
             'overall_payments': overall_payments,
             'outstanding': outstanding,


### PR DESCRIPTION
## Summary
- show "Add Job Entry" shortcut on contractor dashboard for quick access
- expose first active project in view context to build shortcut link
- update dashboard tests for new button

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b2755c2df08330a0afd2f638b52187