### PR TITLE
feat: allow adding payments from contractor dashboard

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -37,5 +37,6 @@
 <a href="{% url 'dashboard:project_list' %}" class="btn btn-primary">View Projects</a>
 {% if first_project %}
 <a href="{% url 'dashboard:add_job_entry' first_project.pk %}" class="btn btn-secondary ms-2">Add Job Entry</a>
+<a href="{% url 'dashboard:add_payment' first_project.pk %}" class="btn btn-secondary ms-2">Add Payment</a>
 {% endif %}
 {% endblock %}

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -212,11 +212,13 @@ class ReportButtonPlacementTests(TestCase):
         self.assertNotContains(response, "Contractor Summary Report")
         self.assertNotContains(response, "Customer Reports")
         self.assertNotContains(response, "Add Job Entry")
+        self.assertNotContains(response, "Add Payment")
 
-    def test_contractor_summary_shows_job_entry_button_with_project(self):
+    def test_contractor_summary_shows_job_and_payment_buttons_with_project(self):
         self.contractor.projects.create(name="Proj", start_date="2024-01-01")
         response = self.client.get(reverse("dashboard:contractor_summary"))
         self.assertContains(response, "Add Job Entry")
+        self.assertContains(response, "Add Payment")
 
     def test_project_list_shows_contractor_summary_report_button(self):
         self.contractor.projects.create(name="Proj", start_date="2024-01-01")


### PR DESCRIPTION
## Summary
- show Add Payment option on contractor summary page
- test contractor dashboard shows Add Payment button when project exists

## Testing
- `python jobtracker/manage.py test dashboard`

------
https://chatgpt.com/codex/tasks/task_e_68b2764f48cc8330bd4a084c4c2d0fbf