### PR TITLE
Improve table responsiveness for mobile devices

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -31,6 +31,20 @@
 </div>
 {% if not report %}
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.table-responsive table').forEach(function (table) {
+        const headers = Array.from(table.querySelectorAll('thead th')).map(th => th.innerText.trim());
+        table.querySelectorAll('tbody tr').forEach(function (row) {
+            Array.from(row.children).forEach(function (cell, index) {
+                if (!cell.hasAttribute('data-label') && headers[index]) {
+                    cell.setAttribute('data-label', headers[index]);
+                }
+            });
+        });
+    });
+});
+</script>
 {% endif %}
 </body>
 </html>

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -100,3 +100,40 @@ a:hover {
     width: 100%;
     overflow-x: auto;
 }
+
+@media (max-width: 576px) {
+    .table-responsive {
+        overflow-x: hidden;
+    }
+    .table-responsive table {
+        width: 100%;
+    }
+    .table-responsive thead {
+        display: none;
+    }
+    .table-responsive tbody,
+    .table-responsive tr,
+    .table-responsive td {
+        display: block;
+        width: 100%;
+    }
+    .table-responsive tr {
+        margin-bottom: 1rem;
+        border: 1px solid #dee2e6;
+        border-radius: 0.25rem;
+    }
+    .table-responsive td {
+        text-align: right;
+        padding-left: 50%;
+        position: relative;
+    }
+    .table-responsive td::before {
+        content: attr(data-label);
+        position: absolute;
+        left: 0;
+        width: 50%;
+        padding-left: 0.5rem;
+        font-weight: bold;
+        text-align: left;
+    }
+}


### PR DESCRIPTION
## Summary
- Add CSS rules to reformat tables into stacked cards on small screens
- Automatically label table cells with headers via JavaScript for better mobile readability

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b277684444833097a969ee28bdec1b