### PR TITLE
Hide empty columns on mobile

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -34,7 +34,20 @@
 <script>
 document.addEventListener('DOMContentLoaded', function () {
     document.querySelectorAll('.table-responsive table').forEach(function (table) {
-        const headers = Array.from(table.querySelectorAll('thead th')).map(th => th.innerText.trim());
+        const ths = Array.from(table.querySelectorAll('thead th'));
+        const headers = ths.map(th => th.innerText.trim());
+
+        if (window.innerWidth <= 576) {
+            ths.forEach(function (th, index) {
+                const cells = Array.from(table.querySelectorAll('tbody tr')).map(row => row.children[index]);
+                const hasContent = cells.some(cell => cell && cell.textContent.trim() !== '');
+                if (!hasContent) {
+                    th.style.display = 'none';
+                    cells.forEach(cell => { if (cell) cell.style.display = 'none'; });
+                }
+            });
+        }
+
         table.querySelectorAll('tbody tr').forEach(function (row) {
             Array.from(row.children).forEach(function (cell, index) {
                 if (!cell.hasAttribute('data-label') && headers[index]) {


### PR DESCRIPTION
## Summary
- Hide table columns that contain no data on small screens

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b27dfbb8908330be09fb5fd5aee6b9