### PR TITLE
fix: hide empty columns on mobile projects page

### DIFF
--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -127,6 +127,9 @@ a:hover {
         padding-left: 50%;
         position: relative;
     }
+    .table-responsive td:empty {
+        display: none;
+    }
     .table-responsive td::before {
         content: attr(data-label);
         position: absolute;


### PR DESCRIPTION
## Summary
- hide empty table cells in mobile view to prevent stray column fragments on the projects page

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b27fb1065c833093feb3c20206dc99