### PR TITLE
Fix contractor job report PDF column headers

### DIFF
--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -101,7 +101,7 @@ a:hover {
     overflow-x: auto;
 }
 
-@media (max-width: 576px) {
+@media screen and (max-width: 576px) {
     .table-responsive {
         overflow-x: hidden;
     }


### PR DESCRIPTION
## Summary
- ensure responsive CSS only applies on screens so contractor job report PDF keeps table headers

## Testing
- `python jobtracker/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b28741a1f08330baa9d4442ba21cba