### PR TITLE
Fix contractor job report PDF column headers

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
@@ -16,16 +16,16 @@
     <table class="table table-bordered" style="width:100%;">
         <thead class="table-light">
             <tr>
-                <th style="text-align:left; width:12%;">Date</th>
-                <th style="text-align:left; width:25%;">Description</th>
-                <th style="text-align:left; width:15%;">Asset</th>
-                <th style="text-align:left; width:15%;">Employee</th>
-                <th style="text-align:left; width:15%;">Material</th>
+                <th style="text-align:left; width:10%;">Date</th>
+                <th style="text-align:left; width:20%;">Description</th>
+                <th style="text-align:left; width:12%;">Asset</th>
+                <th style="text-align:left; width:12%;">Employee</th>
+                <th style="text-align:left; width:12%;">Material</th>
                 <th style="text-align:right; width:8%;">Hours / Qty</th>
-                <th style="text-align:right; width:10%;">Actual Cost</th>
-                <th style="text-align:right; width:10%;">Billable Amount</th>
-                <th style="text-align:right; width:10%;">Profit</th>
-                <th style="text-align:right; width:10%;">Margin</th>
+                <th style="text-align:right; width:8%;">Actual Cost</th>
+                <th style="text-align:right; width:8%;">Billable Amount</th>
+                <th style="text-align:right; width:5%;">Profit</th>
+                <th style="text-align:right; width:5%;">Margin</th>
             </tr>
         </thead>
         <tbody>

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -101,7 +101,7 @@ a:hover {
     overflow-x: auto;
 }
 
-@media (max-width: 576px) {
+@media screen and (max-width: 576px) {
     .table-responsive {
         overflow-x: hidden;
     }


### PR DESCRIPTION
## Summary
- ensure responsive CSS only applies on screens so contractor job report PDF keeps table headers
- balance contractor job report column widths so PDF layout is readable

## Testing
- `python jobtracker/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b28741a1f08330baa9d4442ba21cba