### PR TITLE
Fix contractor report PDF column layout

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -11,25 +11,25 @@
 {% if not report %}
 <a href="?export=pdf" class="btn btn-secondary mb-3 d-print-none">Download PDF</a>
 {% endif %}
-<div class="table-responsive">
-    <table class="table table-bordered">
+<div {% if not report %}class="table-responsive"{% endif %}>
+    <table class="table table-bordered" style="width:100%;">
         <thead class="table-light">
             <tr>
-                <th style="text-align:left;">Project</th>
-                <th style="text-align:right;">Actual Cost</th>
-                <th style="text-align:right;">Billable Total</th>
-                <th style="text-align:right;">Profit</th>
-                <th style="text-align:right;">Margin</th>
+                <th style="text-align:left; width:40%;">Project</th>
+                <th style="text-align:right; width:15%;">Actual Cost</th>
+                <th style="text-align:right; width:15%;">Billable Total</th>
+                <th style="text-align:right; width:15%;">Profit</th>
+                <th style="text-align:right; width:15%;">Margin</th>
             </tr>
         </thead>
         <tbody>
         {% for p in projects %}
             <tr>
-                <td style="text-align:left;">{{ p.name }}</td>
-                <td style="text-align:right;">${{ p.total_cost|default:0 }}</td>
-                <td style="text-align:right;">${{ p.total_billable|default:0 }}</td>
-                <td style="text-align:right;">${{ p.profit|default:0 }}</td>
-                <td style="text-align:right;">{{ p.margin|floatformat:2 }}%</td>
+                <td style="text-align:left; width:40%; word-wrap:break-word;">{{ p.name }}</td>
+                <td style="text-align:right; width:15%;">${{ p.total_cost|default:0 }}</td>
+                <td style="text-align:right; width:15%;">${{ p.total_billable|default:0 }}</td>
+                <td style="text-align:right; width:15%;">${{ p.profit|default:0 }}</td>
+                <td style="text-align:right; width:15%;">{{ p.margin|floatformat:2 }}%</td>
             </tr>
         {% empty %}
             <tr><td colspan="5">No projects.</td></tr>


### PR DESCRIPTION
## Summary
- Ensure contractor report PDF table spans full width and uses defined column widths
- Wrap project names to avoid overly narrow PDF columns

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b2919a35348330943eba940ab00933