### PR TITLE
Use landscape orientation for contractor job report

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
@@ -2,6 +2,11 @@
 {% load static %}
 {% block title %}Contractor Job Report{% endblock %}
 {% block content %}
+{% if report %}
+<style>
+@page { size: landscape; }
+</style>
+{% endif %}
 <div class="text-center mb-3">
   {% if contractor_logo_url %}
   <img src="{{ contractor_logo_url }}" alt="Contractor logo thumbnail" style="height:60px;" />


### PR DESCRIPTION
## Summary
- render contractor job report pages in landscape orientation when exporting to PDF so all columns fit

## Testing
- `python jobtracker/manage.py test dashboard`

------
https://chatgpt.com/codex/tasks/task_e_68b34fefbb9c8330b248e1fe0c81ef9f