### PR TITLE
Fix job entry form mobile layout

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -179,6 +179,7 @@
 document.addEventListener('DOMContentLoaded', function () {
     // Enhanced responsive table handling
     document.querySelectorAll('.table-responsive table').forEach(function (table) {
+        if (table.classList.contains('no-stack')) return;
         const ths = Array.from(table.querySelectorAll('thead th'));
         const headers = ths.map(th => th.innerText.trim());
 

--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -57,7 +57,7 @@
                         </div>
                         <div class="card-body p-0">
                             <div class="table-responsive">
-                                <table class="table table-hover mb-0" id="entries-table">
+                                <table class="table table-hover mb-0 no-stack" id="entries-table">
                                     <thead class="table-light">
                                         <tr>
                                             <th style="width: 10%;">

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -686,41 +686,41 @@ textarea.form-control {
         padding: 16px;
     }
     
-    .table thead {
+    .table:not(.no-stack) thead {
         display: none;
     }
-    
-    .table tbody,
-    .table tr,
-    .table td {
+
+    .table:not(.no-stack) tbody,
+    .table:not(.no-stack) tr,
+    .table:not(.no-stack) td {
         display: block;
         width: 100%;
     }
-    
-    .table tr {
+
+    .table:not(.no-stack) tr {
         margin-bottom: 16px;
         border: 1px solid var(--border-color);
         border-radius: var(--radius-md);
         box-shadow: var(--shadow-sm);
     }
-    
-    .table td {
+
+    .table:not(.no-stack) td {
         text-align: right;
         padding-left: 50%;
         position: relative;
         border: none;
         border-bottom: 1px solid var(--border-color);
     }
-    
-    .table td:last-child {
+
+    .table:not(.no-stack) td:last-child {
         border-bottom: none;
     }
-    
-    .table td:empty {
+
+    .table:not(.no-stack) td:empty {
         display: none;
     }
-    
-    .table td::before {
+
+    .table:not(.no-stack) td::before {
         content: attr(data-label);
         position: absolute;
         left: 16px;


### PR DESCRIPTION
## Summary
- avoid responsive stacking on job entry form table so all fields appear
- skip responsive column-hiding script for tables marked `no-stack`
- scope mobile table styles to exclude `no-stack` tables

## Testing
- `python manage.py test` *(fails: test_contractor_summary_report_title, test_project_list_shows_contractor_summary_report_button, test_contractor_job_report_shows_cost_profit_margin, test_customer_report_shows_payments_and_outstanding, test_contractor_summary_shows_job_and_payment_buttons_with_project)*

------
https://chatgpt.com/codex/tasks/task_e_68b39815e3488330a1e77ede7f932d8d