### PR TITLE
Fix job entry totals not updating on input

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -262,7 +262,8 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     // Update totals when inputs change
-    container.addEventListener('input change', updateTotals);
+    container.addEventListener('input', updateTotals);
+    container.addEventListener('change', updateTotals);
     
     function updateTotals() {
         let totalHours = 0;


### PR DESCRIPTION
## Summary
- ensure totals recompute when modifying job entry fields

## Testing
- `python manage.py test` *(fails: failures=3, errors=2)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a2eccf748330ae637ae9393723b8