### PR TITLE
Fix logout 405 error by using POST form

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -136,9 +136,12 @@
                     <i class="fas fa-cog me-2"></i>Admin
                 </a>
             {% endif %}
-            <a class="nav-link fw-semibold" href="{% url 'logout' %}">
-                <i class="fas fa-sign-out-alt me-2"></i>Logout
-            </a>
+            <form class="d-inline" method="post" action="{% url 'logout' %}">
+                {% csrf_token %}
+                <button type="submit" class="nav-link btn btn-link fw-semibold">
+                    <i class="fas fa-sign-out-alt me-2"></i>Logout
+                </button>
+            </form>
         </div>
     </div>
 </nav>


### PR DESCRIPTION
## Summary
- Replace logout link with POST form to work with Django 5 logout view

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ac561ffc8330869dda05f108715f