### PR TITLE
Fix contractor logout redirect to login page

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -136,9 +136,13 @@
                     <i class="fas fa-cog me-2"></i>Admin
                 </a>
             {% endif %}
-            <a class="nav-link fw-semibold" href="{% url 'logout' %}">
-                <i class="fas fa-sign-out-alt me-2"></i>Logout
-            </a>
+            <form class="d-inline" method="post" action="{% url 'logout' %}">
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{% url 'login' %}">
+                <button type="submit" class="nav-link btn btn-link fw-semibold">
+                    <i class="fas fa-sign-out-alt me-2"></i>Logout
+                </button>
+            </form>
         </div>
     </div>
 </nav>

--- a/jobtracker/jobtracker/settings.py
+++ b/jobtracker/jobtracker/settings.py
@@ -108,3 +108,4 @@ MEDIA_ROOT = Path(os.environ.get('MEDIA_ROOT', BASE_DIR / 'media'))
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/accounts/login/'


### PR DESCRIPTION
## Summary
- Redirect contractor dashboard logout to login page instead of admin console
- Configure logout to send users to the separate login screen

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ac561ffc8330869dda05f108715f