### PR TITLE
fix overlapping labels on login form

### DIFF
--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -494,6 +494,19 @@ textarea::placeholder {
     opacity: 0.7;
 }
 
+/* Prevent placeholder text from overlapping floating labels */
+.form-floating > .form-control::placeholder {
+    color: transparent !important;
+    opacity: 0 !important;
+}
+
+/* Adjust padding when using floating labels */
+.form-floating > .form-control:focus,
+.form-floating > .form-control:not(:placeholder-shown) {
+    padding-top: 1.625rem;
+    padding-bottom: 0.625rem;
+}
+
 /* Form text/help text */
 .form-text {
     color: #6c757d;


### PR DESCRIPTION
## Summary
- ensure floating labels don't overlap by hiding placeholders and adjusting padding

## Testing
- `python jobtracker/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b3af28950883308f411bafba1aba3a