### PR TITLE
Move Add Entry button to bottom of job entry form

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -46,14 +46,9 @@
                     <!-- Job Entries -->
                     <div class="card">
                         <div class="card-header bg-light">
-                            <div class="d-flex justify-content-between align-items-center">
-                                <h6 class="mb-0">
-                                    <i class="fas fa-list me-2"></i>Job Entries
-                                </h6>
-                                <button type="button" id="add-row" class="btn btn-success btn-sm">
-                                    <i class="fas fa-plus me-1"></i>Add Entry
-                                </button>
-                            </div>
+                            <h6 class="mb-0">
+                                <i class="fas fa-list me-2"></i>Job Entries
+                            </h6>
                         </div>
                         <div class="card-body" id="entries-container">
                             <div class="entry-row border rounded p-3 mb-3">
@@ -123,6 +118,13 @@
                                         <div class="form-text">Detailed description of the work performed</div>
                                     </div>
                                 </div>
+                            </div>
+                        </div>
+                        <div class="card-body pt-0">
+                            <div class="text-end">
+                                <button type="button" id="add-row" class="btn btn-success btn-sm">
+                                    <i class="fas fa-plus me-1"></i>Add Entry
+                                </button>
                             </div>
                         </div>
                         <div class="card-footer bg-light">


### PR DESCRIPTION
## Summary
- relocate Add Entry button in the job entry form to the bottom below existing entries
- clean header layout

## Testing
- `python jobtracker/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b3c127d384833098fc6bca6564b400