### PR TITLE
Use original contractor logos on dashboards and thumbnails in PDFs

### DIFF
--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -113,9 +113,40 @@ class CustomerReportHeaderTests(TestCase):
         url = reverse("dashboard:customer_report", args=[project.pk])
         response = self.client.get(url)
 
-        self.assertContains(response, contractor.logo_thumbnail.url)
+        self.assertContains(response, contractor.logo.url)
         self.assertContains(response, contractor.name)
         self.assertContains(response, "Summary of Work")
+
+    def test_customer_report_pdf_uses_thumbnail_logo(self):
+        """PDF export should use the contractor's thumbnail logo."""
+
+        logo_content = (
+            b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00"
+            b"\x00\x00\x00\xff\xff\xff!\xf9\x04\x01\n\x00\x01\x00,"
+            b"\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;"
+        )
+        logo_file = SimpleUploadedFile("logo.gif", logo_content, content_type="image/gif")
+
+        contractor = Contractor.objects.create(
+            name="Test Contractor", email="user@example.com", logo=logo_file
+        )
+        ContractorUser.objects.create_user(
+            email="user@example.com", password="secret", contractor=contractor
+        )
+
+        project = contractor.projects.create(name="Proj", start_date="2024-01-01")
+
+        self.client.post(
+            reverse("login"), {"username": "user@example.com", "password": "secret"}
+        )
+
+        url = reverse("dashboard:customer_report", args=[project.pk])
+        from unittest.mock import patch
+
+        with patch("dashboard.views.pisa", None):
+            response = self.client.get(url + "?export=pdf")
+
+        self.assertContains(response, contractor.logo_thumbnail.url)
 
 
 class CustomerReportPaymentsTests(TestCase):

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -281,12 +281,12 @@ def contractor_report(request):
             unprofitable += 1
     avg_margin = (total_margin / len(projects)) if projects else Decimal("0")
     roi = (total_profit / total_cost * Decimal("100")) if total_cost else None
+    export_pdf = request.GET.get("export") == "pdf"
     logo_url = (
         contractor.logo_thumbnail.url
-        if contractor and contractor.logo_thumbnail
-        else None
+        if export_pdf and contractor and contractor.logo_thumbnail
+        else contractor.logo.url if contractor and contractor.logo else None
     )
-    export_pdf = request.GET.get("export") == "pdf"
     context = {
         "contractor": contractor,
         "projects": projects,
@@ -322,12 +322,12 @@ def customer_report(request, pk):
     payments = list(project.payments.all())
     total_payments = project.payments.aggregate(total=Sum("amount"))["total"] or 0
     outstanding = total - (total_payments or 0)
+    export_pdf = request.GET.get("export") == "pdf"
     logo_url = (
         contractor.logo_thumbnail.url
-        if contractor and contractor.logo_thumbnail
-        else None
+        if export_pdf and contractor and contractor.logo_thumbnail
+        else contractor.logo.url if contractor and contractor.logo else None
     )
-    export_pdf = request.GET.get("export") == "pdf"
     context = {
         "contractor": contractor,
         "project": project,
@@ -377,12 +377,12 @@ def contractor_job_report(request, pk):
     payments = list(project.payments.all())
     total_payments = project.payments.aggregate(total=Sum("amount"))["total"] or 0
     outstanding = total_billable - (total_payments or 0)
+    export_pdf = request.GET.get("export") == "pdf"
     logo_url = (
         contractor.logo_thumbnail.url
-        if contractor and contractor.logo_thumbnail
-        else None
+        if export_pdf and contractor and contractor.logo_thumbnail
+        else contractor.logo.url if contractor and contractor.logo else None
     )
-    export_pdf = request.GET.get("export") == "pdf"
     context = {
         "contractor": contractor,
         "project": project,


### PR DESCRIPTION
## Summary
- Display contractors' original logos with transparency across dashboard web pages
- Render thumbnail logos only when exporting dashboard reports to PDF
- Add tests covering HTML vs PDF logo usage

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d0eaccd48330b0d08b5b7d9a3374