### PR TITLE
Center footer text on mobile

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -164,12 +164,12 @@
 <footer class="mt-5 py-4 bg-white border-top">
     <div class="container">
         <div class="row">
-            <div class="col-md-6">
+            <div class="col-md-6 text-center text-md-start">
                 <p class="text-muted mb-0">
                     <small>&copy; 2025 Squire Enterprises. All rights reserved.</small>
                 </p>
             </div>
-            <div class="col-md-6 text-end">
+            <div class="col-md-6 text-center text-md-end">
                 <p class="text-muted mb-0">
                     <small>Job Tracking System v2.0</small>
                 </p>


### PR DESCRIPTION
## Summary
- Center footer copyright and application name on small screens for a cleaner layout

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b3dd1bfbf8833083cce945443918e9