### PR TITLE
Format currency with thousand separators

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load static humanize %}
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
@@ -1,5 +1,5 @@
 {% extends 'dashboard/base.html' %}
-{% load static %}
+{% load static humanize %}
 {% block title %}Contractor Job Report{% endblock %}
 {% block content %}
 
@@ -82,9 +82,9 @@
                     {% endif %}
                 </td>
                 <td class="text-right" data-label="Hours/Qty">{{ e.hours|floatformat:2 }}</td>
-                <td class="text-right" data-label="Actual Cost">${{ e.cost_amount|floatformat:2 }}</td>
-                <td class="text-right" data-label="Billable Amount">${{ e.billable_amount|floatformat:2 }}</td>
-                <td class="text-right" data-label="Profit">${{ e.profit|floatformat:2 }}</td>
+                <td class="text-right" data-label="Actual Cost">${{ e.cost_amount|floatformat:2|intcomma }}</td>
+                <td class="text-right" data-label="Billable Amount">${{ e.billable_amount|floatformat:2|intcomma }}</td>
+                <td class="text-right" data-label="Profit">${{ e.profit|floatformat:2|intcomma }}</td>
                 <td class="text-right" data-label="Margin">{{ e.margin|floatformat:2 }}%</td>
             </tr>
         {% empty %}
@@ -100,9 +100,9 @@
             <td colspan="6" class="text-right">
                 <strong><i class="fas fa-calculator me-2"></i>TOTALS</strong>
             </td>
-            <td class="text-right"><strong>${{ total_cost|floatformat:2 }}</strong></td>
-            <td class="text-right"><strong>${{ total_billable|floatformat:2 }}</strong></td>
-            <td class="text-right"><strong>${{ total_profit|floatformat:2 }}</strong></td>
+            <td class="text-right"><strong>${{ total_cost|floatformat:2|intcomma }}</strong></td>
+            <td class="text-right"><strong>${{ total_billable|floatformat:2|intcomma }}</strong></td>
+            <td class="text-right"><strong>${{ total_profit|floatformat:2|intcomma }}</strong></td>
             <td class="text-right"><strong>{{ overall_margin|floatformat:2 }}%</strong></td>
         </tr>
         </tbody>
@@ -129,12 +129,12 @@
                 {% for p in payments %}
                     <tr>
                         <td class="text-left" data-label="Date">{{ p.date|date:"m/d/Y" }}</td>
-                        <td class="text-right" data-label="Amount">${{ p.amount|floatformat:2 }}</td>
+                        <td class="text-right" data-label="Amount">${{ p.amount|floatformat:2|intcomma }}</td>
                     </tr>
                 {% endfor %}
                 <tr class="totals-row">
                     <td class="text-right"><strong>Total Payments</strong></td>
-                    <td class="text-right"><strong>${{ total_payments|floatformat:2 }}</strong></td>
+                    <td class="text-right"><strong>${{ total_payments|floatformat:2|intcomma }}</strong></td>
                 </tr>
                 </tbody>
             </table>
@@ -164,11 +164,11 @@
         <i class="fas fa-info-circle fa-2x me-3"></i>
         <div>
             <h6 class="mb-1">Outstanding Balance</h6>
-            <p class="mb-0 fs-4 fw-bold">${{ outstanding|floatformat:2 }}</p>
+            <p class="mb-0 fs-4 fw-bold">${{ outstanding|floatformat:2|intcomma }}</p>
         </div>
     </div>
     {% else %}
-    <p><strong>Outstanding Balance: ${{ outstanding|floatformat:2 }}</strong></p>
+    <p><strong>Outstanding Balance: ${{ outstanding|floatformat:2|intcomma }}</strong></p>
     {% endif %}
 </div>
 

--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -1,5 +1,5 @@
 {% extends 'dashboard/base.html' %}
-{% load static %}
+{% load static humanize %}
 {% block title %}Contractor Summary Report{% endblock %}
 {% block content %}
 
@@ -44,21 +44,21 @@
         <div class="summary-card" style="background: var(--success-gradient);">
             <i class="fas fa-dollar-sign fa-2x mb-3"></i>
             <h5 class="card-title">Total Revenue</h5>
-            <p class="card-text">${{ total_revenue|floatformat:2 }}</p>
+            <p class="card-text">${{ total_revenue|floatformat:2|intcomma }}</p>
         </div>
     </div>
     <div class="col-md-3">
         <div class="summary-card" style="background: var(--warning-gradient);">
             <i class="fas fa-coins fa-2x mb-3"></i>
             <h5 class="card-title">Total Cost</h5>
-            <p class="card-text">${{ total_cost|floatformat:2 }}</p>
+            <p class="card-text">${{ total_cost|floatformat:2|intcomma }}</p>
         </div>
     </div>
     <div class="col-md-3">
         <div class="summary-card" style="background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%);">
             <i class="fas fa-chart-line fa-2x mb-3"></i>
             <h5 class="card-title">Total Profit</h5>
-            <p class="card-text">${{ total_profit|floatformat:2 }}</p>
+            <p class="card-text">${{ total_profit|floatformat:2|intcomma }}</p>
         </div>
     </div>
 </div>
@@ -111,17 +111,17 @@
                 </td>
                 <td class="text-right" data-label="Actual Cost">
                     <span class="{% if not report %}text-danger fw-semibold{% endif %}">
-                        ${{ p.total_cost|default:0|floatformat:2 }}
+                        ${{ p.total_cost|default:0|floatformat:2|intcomma }}
                     </span>
                 </td>
                 <td class="text-right" data-label="Billable Total">
                     <span class="{% if not report %}text-primary fw-semibold{% endif %}">
-                        ${{ p.total_billable|default:0|floatformat:2 }}
+                        ${{ p.total_billable|default:0|floatformat:2|intcomma }}
                     </span>
                 </td>
                 <td class="text-right" data-label="Profit">
                     <span class="{% if not report %}{% if p.profit >= 0 %}text-success{% else %}text-danger{% endif %} fw-semibold{% endif %}">
-                        {% if p.profit >= 0 %}+{% endif %}${{ p.profit|default:0|floatformat:2 }}
+                        {% if p.profit >= 0 %}+{% endif %}${{ p.profit|default:0|floatformat:2|intcomma }}
                     </span>
                 </td>
                 <td class="text-right" data-label="Margin">

--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -1,5 +1,5 @@
 {% extends 'dashboard/base.html' %}
-{% load static %}
+{% load static humanize %}
 {% block title %}Dashboard{% endblock %}
 {% block content %}
 
@@ -20,21 +20,21 @@
         <div class="summary-card slide-up">
             <i class="fas fa-dollar-sign fa-2x mb-3"></i>
             <h5 class="card-title">Total Billable</h5>
-            <p class="card-text">${{ overall_billable|floatformat:2 }}</p>
+            <p class="card-text">${{ overall_billable|floatformat:2|intcomma }}</p>
         </div>
     </div>
     <div class="col-md-4 mb-3">
         <div class="summary-card slide-up" style="background: var(--success-gradient); animation-delay: 0.1s;">
             <i class="fas fa-credit-card fa-2x mb-3"></i>
             <h5 class="card-title">Total Payments</h5>
-            <p class="card-text">${{ overall_payments|floatformat:2 }}</p>
+            <p class="card-text">${{ overall_payments|floatformat:2|intcomma }}</p>
         </div>
     </div>
     <div class="col-md-4 mb-3">
         <div class="summary-card slide-up" style="{% if outstanding > 0 %}background: var(--warning-gradient);{% else %}background: var(--success-gradient);{% endif %} animation-delay: 0.2s;">
             <i class="fas fa-balance-scale fa-2x mb-3"></i>
             <h5 class="card-title">Outstanding</h5>
-            <p class="card-text">${{ outstanding|floatformat:2 }}</p>
+            <p class="card-text">${{ outstanding|floatformat:2|intcomma }}</p>
         </div>
     </div>
 </div>

--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -1,5 +1,5 @@
 {% extends 'dashboard/base.html' %}
-{% load static %}
+{% load static humanize %}
 {% block title %}Customer Report{% endblock %}
 {% block content %}
 
@@ -79,7 +79,7 @@
                     {% endif %}
                 </td>
                 <td class="text-right" data-label="Hours/Qty">{{ e.hours|floatformat:2 }}</td>
-                <td class="text-right" data-label="Billable Amount">${{ e.billable_amount|floatformat:2 }}</td>
+                <td class="text-right" data-label="Billable Amount">${{ e.billable_amount|floatformat:2|intcomma }}</td>
             </tr>
         {% empty %}
             <tr>
@@ -94,7 +94,7 @@
             <td colspan="6" class="text-right">
                 <strong><i class="fas fa-calculator me-2"></i>TOTAL</strong>
             </td>
-            <td class="text-right"><strong>${{ total|floatformat:2 }}</strong></td>
+            <td class="text-right"><strong>${{ total|floatformat:2|intcomma }}</strong></td>
         </tr>
         </tbody>
     </table>
@@ -120,12 +120,12 @@
                 {% for p in payments %}
                     <tr>
                         <td class="text-left" data-label="Date">{{ p.date|date:"m/d/Y" }}</td>
-                        <td class="text-right" data-label="Amount">${{ p.amount|floatformat:2 }}</td>
+                        <td class="text-right" data-label="Amount">${{ p.amount|floatformat:2|intcomma }}</td>
                     </tr>
                 {% endfor %}
                 <tr class="totals-row">
                     <td class="text-right"><strong>Total Payments</strong></td>
-                    <td class="text-right"><strong>${{ total_payments|floatformat:2 }}</strong></td>
+                    <td class="text-right"><strong>${{ total_payments|floatformat:2|intcomma }}</strong></td>
                 </tr>
                 </tbody>
             </table>
@@ -156,16 +156,16 @@
             <i class="fas {% if outstanding > 0 %}fa-exclamation-triangle{% else %}fa-check-circle{% endif %} fa-2x me-3"></i>
             <div>
                 <h6 class="mb-1">Outstanding Balance</h6>
-                <p class="mb-0 fs-4 fw-bold">${{ outstanding|floatformat:2 }}</p>
+                <p class="mb-0 fs-4 fw-bold">${{ outstanding|floatformat:2|intcomma }}</p>
                 {% if outstanding <= 0 %}
                 <small class="text-muted">This project is fully paid!</small>
                 {% endif %}
-                <span class="visually-hidden">Outstanding Balance: ${{ outstanding|floatformat:2 }}</span>
+                <span class="visually-hidden">Outstanding Balance: ${{ outstanding|floatformat:2|intcomma }}</span>
             </div>
         </div>
     </div>
     {% else %}
-    <p><strong>Outstanding Balance: ${{ outstanding|floatformat:2 }}</strong></p>
+    <p><strong>Outstanding Balance: ${{ outstanding|floatformat:2|intcomma }}</strong></p>
     {% endif %}
 </div>
 
@@ -177,7 +177,7 @@
             <div class="card-body">
                 <i class="fas fa-dollar-sign fa-2x text-primary mb-2"></i>
                 <h6 class="card-title">Total Work</h6>
-                <h4 class="text-primary">${{ total|floatformat:2 }}</h4>
+                <h4 class="text-primary">${{ total|floatformat:2|intcomma }}</h4>
             </div>
         </div>
     </div>
@@ -186,7 +186,7 @@
             <div class="card-body">
                 <i class="fas fa-credit-card fa-2x text-success mb-2"></i>
                 <h6 class="card-title">Payments</h6>
-                <h4 class="text-success">${{ total_payments|floatformat:2 }}</h4>
+                <h4 class="text-success">${{ total_payments|floatformat:2|intcomma }}</h4>
             </div>
         </div>
     </div>
@@ -195,7 +195,7 @@
             <div class="card-body">
                 <i class="fas fa-balance-scale fa-2x {% if outstanding > 0 %}text-warning{% else %}text-success{% endif %} mb-2"></i>
                 <h6 class="card-title">Balance</h6>
-                <h4 class="{% if outstanding > 0 %}text-warning{% else %}text-success{% endif %}">${{ outstanding|floatformat:2 }}</h4>
+                <h4 class="{% if outstanding > 0 %}text-warning{% else %}text-success{% endif %}">${{ outstanding|floatformat:2|intcomma }}</h4>
             </div>
         </div>
     </div>

--- a/jobtracker/dashboard/templates/dashboard/jobentry_edit_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_edit_form.html
@@ -1,4 +1,5 @@
 {% extends 'dashboard/base.html' %}
+{% load humanize %}
 {% block title %}Edit Job Entry{% endblock %}
 {% block content %}
 
@@ -47,8 +48,8 @@
                                 <small>
                                     <i class="fas fa-calculator me-1"></i>
                                     <strong>Current Values:</strong><br>
-                                    Cost: ${{ entry.cost_amount|floatformat:2 }}<br>
-                                    Billable: ${{ entry.billable_amount|floatformat:2 }}
+                                    Cost: ${{ entry.cost_amount|floatformat:2|intcomma }}<br>
+                                    Billable: ${{ entry.billable_amount|floatformat:2|intcomma }}
                                 </small>
                             </div>
                         </div>
@@ -64,7 +65,7 @@
                                 <option value="">Select Asset...</option>
                                 {% for asset in assets %}
                                 <option value="{{ asset.id }}" {% if entry.asset_id == asset.id %}selected{% endif %} data-cost="{{ asset.cost_rate }}" data-billable="{{ asset.billable_rate }}">
-                                    {{ asset.name }} (${{ asset.cost_rate }}/hr cost, ${{ asset.billable_rate }}/hr billable)
+                                    {{ asset.name }} (${{ asset.cost_rate|floatformat:2|intcomma }}/hr cost, ${{ asset.billable_rate|floatformat:2|intcomma }}/hr billable)
                                 </option>
                                 {% endfor %}
                             </select>
@@ -78,7 +79,7 @@
                                 <option value="">Select Employee...</option>
                                 {% for emp in employees %}
                                 <option value="{{ emp.id }}" {% if entry.employee_id == emp.id %}selected{% endif %} data-cost="{{ emp.cost_rate }}" data-billable="{{ emp.billable_rate }}">
-                                    {{ emp.name }} (${{ emp.cost_rate }}/hr cost, ${{ emp.billable_rate }}/hr billable)
+                                    {{ emp.name }} (${{ emp.cost_rate|floatformat:2|intcomma }}/hr cost, ${{ emp.billable_rate|floatformat:2|intcomma }}/hr billable)
                                 </option>
                                 {% endfor %}
                             </select>

--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -1,4 +1,5 @@
 {% extends 'dashboard/base.html' %}
+{% load humanize %}
 {% block title %}Add Job Entry{% endblock %}
 {% block content %}
 
@@ -73,7 +74,7 @@
                                             <option value="">Select Asset...</option>
                                             {% for asset in assets %}
                                             <option value="{{ asset.id }}" data-cost="{{ asset.cost_rate }}" data-billable="{{ asset.billable_rate }}">
-                                                {{ asset.name }} (${{ asset.billable_rate }}/hr)
+                                                {{ asset.name }} (${{ asset.billable_rate|floatformat:2|intcomma }}/hr)
                                             </option>
                                             {% endfor %}
                                         </select>
@@ -87,7 +88,7 @@
                                             <option value="">Select Employee...</option>
                                             {% for emp in employees %}
                                             <option value="{{ emp.id }}" data-cost="{{ emp.cost_rate }}" data-billable="{{ emp.billable_rate }}">
-                                                {{ emp.name }} (${{ emp.billable_rate }}/hr)
+                                                {{ emp.name }} (${{ emp.billable_rate|floatformat:2|intcomma }}/hr)
                                             </option>
                                             {% endfor %}
                                         </select>
@@ -313,10 +314,11 @@ document.addEventListener('DOMContentLoaded', function() {
         });
         
         // Update display
+        const formatCurrency = (val) => val.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
         document.getElementById('total-hours').textContent = totalHours.toFixed(2);
-        document.getElementById('total-cost').textContent = totalCost.toFixed(2);
-        document.getElementById('total-billable').textContent = totalBillable.toFixed(2);
-        document.getElementById('total-profit').textContent = (totalBillable - totalCost).toFixed(2);
+        document.getElementById('total-cost').textContent = formatCurrency(totalCost);
+        document.getElementById('total-billable').textContent = formatCurrency(totalBillable);
+        document.getElementById('total-profit').textContent = formatCurrency(totalBillable - totalCost);
         
         // Update profit color
         const profitEl = document.getElementById('total-profit');

--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -1,4 +1,5 @@
 {% extends 'dashboard/base.html' %}
+{% load humanize %}
 {% block title %}{{ project.name }}{% endblock %}
 {% block content %}
 
@@ -28,21 +29,21 @@
         <div class="summary-card">
             <i class="fas fa-dollar-sign fa-2x mb-3"></i>
             <h5 class="card-title">Total Billable</h5>
-            <p class="card-text">${{ total_billable|floatformat:2 }}</p>
+            <p class="card-text">${{ total_billable|floatformat:2|intcomma }}</p>
         </div>
     </div>
     <div class="col-md-4 mb-3">
         <div class="summary-card" style="background: var(--success-gradient);">
             <i class="fas fa-credit-card fa-2x mb-3"></i>
             <h5 class="card-title">Total Payments</h5>
-            <p class="card-text">${{ total_payments|floatformat:2 }}</p>
+            <p class="card-text">${{ total_payments|floatformat:2|intcomma }}</p>
         </div>
     </div>
     <div class="col-md-4 mb-3">
         <div class="summary-card" style="{% if outstanding > 0 %}background: var(--warning-gradient);{% else %}background: var(--success-gradient);{% endif %}">
             <i class="fas fa-balance-scale fa-2x mb-3"></i>
             <h5 class="card-title">Outstanding</h5>
-            <p class="card-text">${{ outstanding|floatformat:2 }}</p>
+            <p class="card-text">${{ outstanding|floatformat:2|intcomma }}</p>
         </div>
     </div>
 </div>
@@ -149,17 +150,17 @@
                                     {{ entry.material_description }}
                                 </span>
                                 {% if entry.material_cost %}
-                                    <small class="text-muted d-block">${{ entry.material_cost|floatformat:2 }}</small>
+                                    <small class="text-muted d-block">${{ entry.material_cost|floatformat:2|intcomma }}</small>
                                 {% endif %}
                             {% else %}
                                 <span class="text-muted">—</span>
                             {% endif %}
                         </td>
                         <td class="text-end" data-label="Cost">
-                            <span class="text-danger fw-semibold">${{ entry.cost_amount|floatformat:2 }}</span>
+                            <span class="text-danger fw-semibold">${{ entry.cost_amount|floatformat:2|intcomma }}</span>
                         </td>
                         <td class="text-end" data-label="Billable">
-                            <span class="text-success fw-semibold">${{ entry.billable_amount|floatformat:2 }}</span>
+                            <span class="text-success fw-semibold">${{ entry.billable_amount|floatformat:2|intcomma }}</span>
                         </td>
                         <td data-label="Description">
                             {% if entry.description %}
@@ -223,7 +224,7 @@
                             <span class="badge bg-light text-dark">{{ payment.date|date:"M d, Y" }}</span>
                         </td>
                         <td class="text-end" data-label="Amount">
-                            <span class="text-success fw-bold fs-5">${{ payment.amount|floatformat:2 }}</span>
+                            <span class="text-success fw-bold fs-5">${{ payment.amount|floatformat:2|intcomma }}</span>
                         </td>
                         <td data-label="Notes">
                             {% if payment.notes %}

--- a/jobtracker/dashboard/templates/dashboard/project_list.html
+++ b/jobtracker/dashboard/templates/dashboard/project_list.html
@@ -1,4 +1,5 @@
 {% extends 'dashboard/base.html' %}
+{% load humanize %}
 {% block title %}Projects{% endblock %}
 {% block content %}
 
@@ -36,19 +37,19 @@
                 <div class="row text-center mb-3">
                     <div class="col-4">
                         <div class="border-end">
-                            <div class="text-primary fw-bold">${{ project.total_billable|floatformat:0 }}</div>
+                            <div class="text-primary fw-bold">${{ project.total_billable|floatformat:0|intcomma }}</div>
                             <small class="text-muted">Billable</small>
                         </div>
                     </div>
                     <div class="col-4">
                         <div class="border-end">
-                            <div class="text-success fw-bold">${{ project.total_payments|floatformat:0 }}</div>
+                            <div class="text-success fw-bold">${{ project.total_payments|floatformat:0|intcomma }}</div>
                             <small class="text-muted">Paid</small>
                         </div>
                     </div>
                     <div class="col-4">
                         <div class="{% if project.outstanding > 0 %}text-warning{% else %}text-success{% endif %} fw-bold">
-                            ${{ project.outstanding|floatformat:0 }}
+                            ${{ project.outstanding|floatformat:0|intcomma }}
                         </div>
                         <small class="text-muted">Outstanding</small>
                     </div>
@@ -127,19 +128,19 @@
               </div>
               <div class="col-md-3 mb-3 mb-md-0">
                   <div class="border-md-end">
-                      <h4 class="text-success mb-0">${{ total_billable|floatformat:0 }}</h4>
+                      <h4 class="text-success mb-0">${{ total_billable|floatformat:0|intcomma }}</h4>
                       <small class="text-muted d-block mt-0">Total Billable</small>
                   </div>
               </div>
               <div class="col-md-3 mb-3 mb-md-0">
                   <div class="border-md-end">
-                      <h4 class="text-info mb-0">${{ total_payments|floatformat:0 }}</h4>
+                      <h4 class="text-info mb-0">${{ total_payments|floatformat:0|intcomma }}</h4>
                       <small class="text-muted d-block mt-0">Total Payments</small>
                   </div>
               </div>
               <div class="col-md-3 mb-3 mb-md-0">
                   <h4 class="{% if total_outstanding > 0 %}text-warning{% else %}text-success{% endif %} mb-0">
-                      ${{ total_outstanding|floatformat:0 }}
+                      ${{ total_outstanding|floatformat:0|intcomma }}
                   </h4>
                   <small class="text-muted d-block mt-0">Outstanding</small>
               </div>

--- a/jobtracker/jobtracker/settings.py
+++ b/jobtracker/jobtracker/settings.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.humanize',
     'tracker',
     'dashboard',
 ]


### PR DESCRIPTION
## Summary
- Show dollar amounts with thousands separators across dashboard and report templates using `intcomma`
- Enable `django.contrib.humanize` to support comma-based formatting
- Format dynamic total fields in job entry form using JavaScript `toLocaleString`

## Testing
- `python jobtracker/manage.py test dashboard`


------
https://chatgpt.com/codex/tasks/task_e_68b3dec5633c8330885320c15eee5c74