### PR TITLE
Display support phone number on contractor dashboard

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -164,6 +164,7 @@
                     <i class="fas fa-headset fa-2x text-success mb-2"></i>
                     <h6>Support</h6>
                     <p class="text-muted small">Get help from our support team</p>
+                    <p class="text-muted small">(413) 519-4637</p>
                 </div>
             </div>
             <div class="col-md-4">


### PR DESCRIPTION
## Summary
- add support phone number to Need Help section on contractor dashboard

## Testing
- `python jobtracker/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e4c51b048330a80ade4f9383fd19