### PR TITLE
Fix project card spacing for monetary summaries

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_list.html
+++ b/jobtracker/dashboard/templates/dashboard/project_list.html
@@ -38,20 +38,20 @@
                     <div class="col-4">
                         <div class="border-end">
                             <div class="text-primary fw-bold">${{ project.total_billable|floatformat:0|intcomma }}</div>
-                            <small class="text-muted">Billable</small>
+                            <small class="text-muted text-nowrap d-block">Billable</small>
                         </div>
                     </div>
                     <div class="col-4">
                         <div class="border-end">
                             <div class="text-success fw-bold">${{ project.total_payments|floatformat:0|intcomma }}</div>
-                            <small class="text-muted">Paid</small>
+                            <small class="text-muted text-nowrap d-block">Paid</small>
                         </div>
                     </div>
                     <div class="col-4">
                         <div class="{% if project.outstanding > 0 %}text-warning{% else %}text-success{% endif %} fw-bold">
                             ${{ project.outstanding|floatformat:0|intcomma }}
                         </div>
-                        <small class="text-muted">Outstanding</small>
+                        <small class="text-muted text-nowrap d-block">Outstanding</small>
                     </div>
                 </div>
                 


### PR DESCRIPTION
## Summary
- ensure billable, paid, and outstanding labels stay on one line on project cards

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e9dcf4748330bda88de2869abb62