### PR TITLE
Remove keyboard shortcut section from dashboard

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -77,7 +77,7 @@
         <div class="card slide-up" style="animation-delay: 0.3s;">
             <div class="card-body">
                 <h5 class="card-title mb-4">
-                    <i class="fas fa-rocket me-2"></i>Quick Actions & Shortcuts
+                    <i class="fas fa-rocket me-2"></i>Quick Actions
                 </h5>
                 
                 <div class="action-buttons">
@@ -100,25 +100,6 @@
                     </a>
                 </div>
                 
-                <div class="mt-4 pt-3 border-top">
-                    <h6 class="text-muted mb-3">
-                        <i class="fas fa-keyboard me-2"></i>Keyboard Shortcuts
-                    </h6>
-                    <div class="row">
-                        <div class="col-md-6">
-                            <small class="text-muted">
-                                <kbd>Ctrl</kbd> + <kbd>N</kbd> - New Job Entry<br>
-                                <kbd>Ctrl</kbd> + <kbd>P</kbd> - Record Payment<br>
-                            </small>
-                        </div>
-                        <div class="col-md-6">
-                            <small class="text-muted">
-                                <kbd>Ctrl</kbd> + <kbd>K</kbd> - Search<br>
-                                <kbd>Ctrl</kbd> + <kbd>R</kbd> - Generate Report
-                            </small>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- remove keyboard shortcut list from contractor dashboard to avoid browser command conflicts
- rename section to "Quick Actions"

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b6640230e083308faaca293bff21ec