### PR TITLE
Fix dashboard back navigation link

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -180,9 +180,9 @@
     <!-- Breadcrumb Navigation (for non-dashboard pages) -->
     {% if not report and request.resolver_match.url_name != 'contractor_summary' %}
     <div class="d-print-none mb-4">
-        <button type="button" id="back-button" class="btn btn-outline-primary" style="display:none;">
+        <a id="back-button" class="btn btn-outline-primary" style="display:none;" role="button">
             <i class="fas fa-arrow-left me-2"></i>Back
-        </button>
+        </a>
     </div>
     {% endif %}
     


### PR DESCRIPTION
## Summary
- Ensure the dashboard "Back" control is an anchor so navigation works

## Testing
- `python jobtracker/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b70b1aa82083308ace1424cac51d15