### PR TITLE
fix: center quick action button text

### DIFF
--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -659,6 +659,9 @@ textarea:focus {
 .action-buttons .btn {
     flex: 1;
     min-width: 140px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 /* Input group styling */


### PR DESCRIPTION
## Summary
- center contractor dashboard quick action button text vertically

## Testing
- `python manage.py test` *(fails: Couldn't find '40.00%' in response)*

------
https://chatgpt.com/codex/tasks/task_e_68b713073bd08330a5d76ce0178fa773