### PR TITLE
Fix missing hours column in customer report

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -586,6 +586,7 @@ body {
                         —
                     {% endif %}
                 </td>
+                <td class="text-right font-mono" data-label="Hours/Qty">{{ e.hours|floatformat:2 }}</td>
                 <td class="text-right font-mono amount" data-label="Amount">${{ e.billable_amount|floatformat:2|intcomma }}</td>
             </tr>
         {% empty %}
@@ -757,5 +758,4 @@ body {
 </div>
 {% endif %}
 
-{% endblock %} font-mono" data-label="Hours/Qty">{{ e.hours|floatformat:2 }}</td>
-                <td class="text-right
+{% endblock %}


### PR DESCRIPTION
## Summary
- display each entry's hours/quantity in the customer report table
- clean up stray template text after endblock

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b7188dd58083308cddcb004e5ec95d