### PR TITLE
Fix time-based greeting on contractor dashboard

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -10,7 +10,8 @@
         <img src="{{ contractor_logo_url }}" alt="Contractor logo" class="img-fluid contractor-logo" style="filter: brightness(0) invert(1);">
     </div>
     {% endif %}
-    <h1><i class="fas fa-tachometer-alt me-3"></i>Good {% now "A" %}{% if "AM" in "now"|date:"A" %}Morning{% else %}{% if "now"|date:"H"|add:0 < 18 %}Afternoon{% else %}Evening{% endif %}{% endif %}!</h1>
+    {% now "H" as current_hour %}
+    <h1><i class="fas fa-tachometer-alt me-3"></i>Good {% if current_hour|add:0 < 12 %}Morning{% elif current_hour|add:0 < 18 %}Afternoon{% else %}Evening{% endif %}!</h1>
     <p>Here's what's happening with your projects today</p>
 </div>
 


### PR DESCRIPTION
## Summary
- compute hour using `{% now "H" as current_hour %}` and conditionally display Morning/Afternoon/Evening greeting

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b71a9355308330a951d935550f3036