### PR TITLE
Show timestamp on report generation messages

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
@@ -348,7 +348,7 @@ body {
     {% endif %}
     <h2>{{ contractor.name|default:contractor.email }}</h2>
     <h1>Contractor Job Report</h1>
-    <div class="project-info">{{ project.name }} • Generated {{ "now"|date:"F d, Y" }}</div>
+    <div class="project-info">{{ project.name }} • Generated {{ "now"|date:"F d, Y \\a\\t g:i A" }}</div>
 </div>
 
 <!-- Export Button -->
@@ -361,7 +361,7 @@ body {
             </a>
         </div>
         <div class="text-muted">
-            <small><i class="fas fa-info-circle me-1"></i>Report generated on {{ "now"|date:"F d, Y" }}</small>
+            <small><i class="fas fa-info-circle me-1"></i>Report generated on {{ "now"|date:"F d, Y \\a\\t g:i A" }}</small>
         </div>
     </div>
 </div>

--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -549,7 +549,7 @@ body {
     {% endif %}
     <h1>Portfolio Summary Report</h1>
     <div class="contractor-info">{{ contractor.name|default:contractor.email }}</div>
-    <div class="report-period">Complete Business Analysis • Generated {{ "now"|date:"F d, Y" }}</div>
+    <div class="report-period">Complete Business Analysis • Generated {{ "now"|date:"F d, Y \\a\\t g:i A" }}</div>
 </div>
 
 <!-- Export Button -->
@@ -562,7 +562,7 @@ body {
             </a>
         </div>
         <div class="text-muted">
-            <small><i class="fas fa-info-circle me-1"></i>Report generated on {{ "now"|date:"F d, Y" }}</small>
+            <small><i class="fas fa-info-circle me-1"></i>Report generated on {{ "now"|date:"F d, Y \\a\\t g:i A" }}</small>
         </div>
     </div>
 </div>

--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -491,7 +491,7 @@ body {
     {% endif %}
     <h2>{{ contractor.name|default:contractor.email }}</h2>
     <h1>Summary of Work</h1>
-    <div class="project-details">{{ project.name }} • {{ "now"|date:"F d, Y" }}</div>
+    <div class="project-details">{{ project.name }} • {{ "now"|date:"F d, Y \\a\\t g:i A" }}</div>
 </div>
 
 <!-- Export Button -->
@@ -504,7 +504,7 @@ body {
             </a>
         </div>
         <div class="text-muted">
-            <small><i class="fas fa-info-circle me-1"></i>Report generated on {{ "now"|date:"F d, Y" }}</small>
+            <small><i class="fas fa-info-circle me-1"></i>Report generated on {{ "now"|date:"F d, Y \\a\\t g:i A" }}</small>
         </div>
     </div>
 </div>
@@ -691,7 +691,7 @@ body {
 <div class="report-footer">
     <div class="thank-you">Thank you for your business!</div>
     <div class="generation-info">
-        <strong>Invoice generated on {{ "now"|date:"F d, Y" }}</strong>
+        <strong>Invoice generated on {{ "now"|date:"F d, Y \\a\\t g:i A" }}</strong>
     </div>
     <div class="company-info">
         {{ contractor.name|default:"Squire Enterprises" }} | Professional Services | 


### PR DESCRIPTION
## Summary
- Include time-of-day in Portfolio Summary, Contractor Job, and Customer report headers and footers
- Ensure "Report generated on" and "Invoice generated on" labels display full timestamps

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b71eb14aa08330a24bfaa2676f2890