### PR TITLE
Handle PDF generation errors and add regression test

### DIFF
--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -399,6 +399,15 @@ class PdfExportTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "application/pdf")
 
+    @patch("dashboard.views.pisa")
+    def test_pdf_export_error_returns_html(self, mock_pisa):
+        mock_pisa.CreatePDF.side_effect = Exception("boom")
+        response = self.client.get(
+            reverse("dashboard:contractor_report") + "?export=pdf"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response["Content-Type"].startswith("text/html"))
+
 
 class JobEntryOrderingTests(TestCase):
     def setUp(self):

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -41,7 +41,10 @@ def _render_pdf(template_src, context, filename):
     template = get_template(template_src)
     html = template.render(context)
     result = BytesIO()
-    pdf = pisa.CreatePDF(html, dest=result, link_callback=link_callback)
+    try:
+        pdf = pisa.CreatePDF(html, dest=result, link_callback=link_callback)
+    except Exception:
+        return None
     if pdf.err:
         return None
     result.seek(0)


### PR DESCRIPTION
## Summary
- Wrap `pisa.CreatePDF` in a try/except to avoid 500 errors during PDF export
- Add regression test ensuring HTML response when PDF generation fails

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b71f81ba588330a03f2adc9ac13d8c