### PR TITLE
Expand job entry summary width to prevent totals overflow

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -50,7 +50,7 @@
 </div>
 
 <div class="row">
-    <div class="col-lg-10">
+    <div class="col-lg-9">
         <form method="post" id="entry-form">
             {% csrf_token %}
             
@@ -237,7 +237,7 @@
     </div>
     
     <!-- Summary Sidebar -->
-    <div class="col-lg-2">
+    <div class="col-lg-3">
         <div class="sticky-top" style="top: 100px;">
             <!-- Daily Summary -->
             <div class="card mb-3">


### PR DESCRIPTION
## Summary
- widen job entry form summary sidebar from col-lg-2 to col-lg-3 and adjust main form to col-lg-9
- prevents Equipment/Labor total from overflowing its container

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b720d9bf44833087949db6ea635fc5