### PR TITLE
feat: use weasyprint for PDF generation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ gunicorn
 psycopg2-binary
 python-dotenv
 Pillow
-xhtml2pdf
+WeasyPrint


### PR DESCRIPTION
## Summary
- replace xhtml2pdf with WeasyPrint for PDF rendering
- trim generated PDFs and handle missing library
- expand tests for WeasyPrint-based PDF exports

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b72ccc11fc8330b2d00582d8fdba3b