### PR TITLE
Add afternoon greeting to contractor dashboard

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -10,8 +10,7 @@
         <img src="{{ contractor_logo_url }}" alt="Contractor logo" class="img-fluid contractor-logo" style="filter: brightness(0) invert(1);">
     </div>
     {% endif %}
-    {% now "H" as current_hour %}
-    <h1><i class="fas fa-tachometer-alt me-3"></i>Good {% if current_hour|add:0 < 12 %}Morning{% elif current_hour|add:0 < 18 %}Afternoon{% else %}Evening{% endif %}!</h1>
+    <h1><i class="fas fa-tachometer-alt me-3"></i>{{ greeting }}!</h1>
     <p>Here's what's happening with your projects today</p>
 </div>
 

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -72,7 +72,15 @@ def contractor_summary(request):
     recent_payments = Payment.objects.filter(
         project__contractor=contractor
     ).select_related('project').order_by('-date')[:5]
-    
+
+    current_hour = timezone.localtime().hour
+    if current_hour < 12:
+        greeting = "Good Morning"
+    elif current_hour < 18:
+        greeting = "Good Afternoon"
+    else:
+        greeting = "Good Evening"
+
     return render(
         request,
         'dashboard/contractor_summary.html',
@@ -86,6 +94,7 @@ def contractor_summary(request):
             'contractor_logo_url': contractor.logo.url if contractor.logo else None,
             'recent_entries': recent_entries,
             'recent_payments': recent_payments,
+            'greeting': greeting,
         },
     )
 


### PR DESCRIPTION
## Summary
- Compute time-of-day greeting server-side to cover morning, afternoon, and evening
- Render greeting text in contractor dashboard header

## Testing
- `python jobtracker/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b731cbf9488330b2b554a4e4178d4f