### PR TITLE
Remove contractor logo from PDF reports

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
@@ -343,9 +343,6 @@ body {
 
 <!-- Report Header -->
 <div class="{% if report %}report-header{% else %}text-center mb-4{% endif %}">
-    {% if contractor_logo_url %}
-    <img src="{{ contractor_logo_url }}" alt="Contractor logo" class="contractor-logo" />
-    {% endif %}
     <h2>{{ contractor.name|default:contractor.email }}</h2>
     <h1>Contractor Job Report</h1>
     <div class="project-info">{{ project.name }} • Generated {{ "now"|date:"F d, Y \\a\\t g:i A" }}</div>

--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -544,9 +544,6 @@ body {
 
 <!-- Report Header -->
 <div class="{% if report %}report-header{% else %}text-center mb-4{% endif %}">
-    {% if contractor_logo_url %}
-    <img src="{{ contractor_logo_url }}" alt="Contractor logo" class="contractor-logo" />
-    {% endif %}
     <h1>Portfolio Summary Report</h1>
     <div class="contractor-info">{{ contractor.name|default:contractor.email }}</div>
     <div class="report-period">Complete Business Analysis • Generated {{ "now"|date:"F d, Y \\a\\t g:i A" }}</div>

--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -486,9 +486,6 @@ body {
 
 <!-- Report Header -->
 <div class="{% if report %}report-header{% else %}text-center mb-4{% endif %}">
-    {% if contractor_logo_url %}
-    <img src="{{ contractor_logo_url }}" alt="Contractor logo" class="contractor-logo" />
-    {% endif %}
     <h2>{{ contractor.name|default:contractor.email }}</h2>
     <h1>Summary of Work</h1>
     <div class="project-details">{{ project.name }} • {{ "now"|date:"F d, Y \\a\\t g:i A" }}</div>

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -107,8 +107,8 @@ class DashboardLogoTests(TestCase):
 
 
 class CustomerReportHeaderTests(TestCase):
-    def test_customer_report_displays_logo_and_name(self):
-        """Customer report should show contractor name, logo, and new title."""
+    def test_customer_report_displays_name(self):
+        """Customer report should show contractor name and new title without logo."""
 
         logo_content = (
             b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00"
@@ -133,13 +133,13 @@ class CustomerReportHeaderTests(TestCase):
         url = reverse("dashboard:customer_report", args=[project.pk])
         response = self.client.get(url)
 
-        self.assertContains(response, contractor.logo.url)
-        self.assertContains(response, "contractor-logo")
+        self.assertNotContains(response, contractor.logo.url)
+        self.assertNotContains(response, "contractor-logo")
         self.assertContains(response, contractor.name)
         self.assertContains(response, "Summary of Work")
 
-    def test_customer_report_pdf_uses_thumbnail_logo(self):
-        """PDF export should use the contractor's thumbnail logo."""
+    def test_customer_report_pdf_renders_without_logo(self):
+        """PDF export should render without contractor logo."""
 
         logo_content = (
             b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00"
@@ -167,8 +167,8 @@ class CustomerReportHeaderTests(TestCase):
         with patch("dashboard.views._render_pdf", return_value=None):
             response = self.client.get(url + "?export=pdf")
 
-        self.assertContains(response, contractor.logo_thumbnail.url)
-        self.assertContains(response, "contractor-logo")
+        self.assertNotContains(response, contractor.logo_thumbnail.url)
+        self.assertNotContains(response, "contractor-logo")
 
 
 class CustomerReportPaymentsTests(TestCase):
@@ -216,7 +216,7 @@ class ContractorSummaryReportTests(TestCase):
         response = self.client.get(reverse("dashboard:contractor_report"))
         self.assertContains(response, "Contractor Summary Report")
 
-    def test_contractor_report_displays_logo(self):
+    def test_contractor_report_excludes_logo(self):
         logo_content = (
             b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00"
             b"\x00\x00\x00\xff\xff\xff!\xf9\x04\x01\n\x00\x01\x00,"
@@ -237,8 +237,8 @@ class ContractorSummaryReportTests(TestCase):
 
         response = self.client.get(reverse("dashboard:contractor_report"))
 
-        self.assertContains(response, contractor.logo.url)
-        self.assertContains(response, "contractor-logo")
+        self.assertNotContains(response, contractor.logo.url)
+        self.assertNotContains(response, "contractor-logo")
 
 
 class ContractorJobReportTests(TestCase):
@@ -270,7 +270,7 @@ class ContractorJobReportTests(TestCase):
         self.assertContains(response, "$20")
         self.assertContains(response, "40.00%")
 
-    def test_contractor_job_report_displays_logo(self):
+    def test_contractor_job_report_excludes_logo(self):
         logo_content = (
             b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00"
             b"\x00\x00\x00\xff\xff\xff!\xf9\x04\x01\n\x00\x01\x00,"
@@ -293,8 +293,8 @@ class ContractorJobReportTests(TestCase):
         url = reverse("dashboard:contractor_job_report", args=[project.pk])
         response = self.client.get(url)
 
-        self.assertContains(response, contractor.logo.url)
-        self.assertContains(response, "contractor-logo")
+        self.assertNotContains(response, contractor.logo.url)
+        self.assertNotContains(response, "contractor-logo")
 
 
 class ReportButtonPlacementTests(TestCase):

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -433,16 +433,9 @@ def contractor_report(request):
     roi = (total_profit / total_cost * Decimal("100")) if total_cost else None
     
     export_pdf = request.GET.get("export") == "pdf"
-    logo_url = (
-        contractor.logo_thumbnail.url
-        if export_pdf and contractor and contractor.logo_thumbnail
-        else contractor.logo.url if contractor and contractor.logo else None
-    )
-    
     context = {
         "contractor": contractor,
         "projects": projects,
-        "contractor_logo_url": logo_url,
         "report": export_pdf,
         "total_revenue": total_revenue,
         "total_cost": total_cost,
@@ -479,18 +472,12 @@ def customer_report(request, pk):
     outstanding = total - (total_payments or 0)
     
     export_pdf = request.GET.get("export") == "pdf"
-    logo_url = (
-        contractor.logo_thumbnail.url
-        if export_pdf and contractor and contractor.logo_thumbnail
-        else contractor.logo.url if contractor and contractor.logo else None
-    )
-    
+
     context = {
         "contractor": contractor,
         "project": project,
         "entries": entries,
         "total": total,
-        "contractor_logo_url": logo_url,
         "report": export_pdf,
         "colspan_before_total": 6,
         "total_columns": 7,
@@ -543,12 +530,7 @@ def contractor_job_report(request, pk):
     outstanding = total_billable - (total_payments or 0)
     
     export_pdf = request.GET.get("export") == "pdf"
-    logo_url = (
-        contractor.logo_thumbnail.url
-        if export_pdf and contractor and contractor.logo_thumbnail
-        else contractor.logo.url if contractor and contractor.logo else None
-    )
-    
+
     context = {
         "contractor": contractor,
         "project": project,
@@ -557,7 +539,6 @@ def contractor_job_report(request, pk):
         "total_cost": total_cost,
         "total_profit": total_profit,
         "overall_margin": overall_margin,
-        "contractor_logo_url": logo_url,
         "report": export_pdf,
         "payments": payments,
         "total_payments": total_payments or 0,

--- a/jobtracker/tracker/context_processors.py
+++ b/jobtracker/tracker/context_processors.py
@@ -38,5 +38,4 @@ def contractor(request):
         if getattr(user, "is_authenticated", False)
         else None
     )
-    logo_url = contract.logo.url if contract and contract.logo else None
-    return {"contractor": contract, "contractor_logo_url": logo_url}
+    return {"contractor": contract}


### PR DESCRIPTION
## Summary
- drop contractor logo placeholders from PDF report templates
- simplify views/context processors by removing contractor logo context
- adjust tests to match logo removal

## Testing
- `python jobtracker/manage.py test dashboard`


------
https://chatgpt.com/codex/tasks/task_e_68b732c8a5c88330adc0baeb7866ae1f