### PR TITLE
Add centralized reports page and navigation links

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -192,6 +192,9 @@
             <a class="nav-link fw-semibold" href="{% url 'dashboard:project_list' %}">
                 <i class="fas fa-project-diagram me-2"></i>Projects
             </a>
+            <a class="nav-link fw-semibold" href="{% url 'dashboard:reports' %}">
+                <i class="fas fa-file-alt me-2"></i>Reports
+            </a>
             {% if user.is_staff %}
                 <a class="nav-link fw-semibold" href="{% url 'admin:index' %}">
                     <i class="fas fa-cog me-2"></i>Admin

--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -31,9 +31,9 @@
         </div>
     </div>
     <div class="col-md-3 mb-3">
-        <div class="quick-action-card warning" onclick="location.href='{% url 'dashboard:contractor_report' %}'">
+        <div class="quick-action-card warning" onclick="location.href='{% url 'dashboard:reports' %}'">
             <i class="fas fa-file-pdf quick-action-icon"></i>
-            <h5 class="mb-2">Generate Report</h5>
+            <h5 class="mb-2">Generate Reports</h5>
             <p class="mb-0">Customer & job reports</p>
         </div>
     </div>

--- a/jobtracker/dashboard/templates/dashboard/reports.html
+++ b/jobtracker/dashboard/templates/dashboard/reports.html
@@ -1,0 +1,70 @@
+{% extends 'dashboard/base.html' %}
+{% load humanize %}
+{% block title %}Reports{% endblock %}
+{% block content %}
+
+<nav aria-label="breadcrumb" class="mb-3">
+    <ol class="breadcrumb breadcrumb-custom">
+        <li class="breadcrumb-item"><a href="{% url 'dashboard:contractor_summary' %}"><i class="fas fa-home me-1"></i>Dashboard</a></li>
+        <li class="breadcrumb-item active">Reports</li>
+    </ol>
+</nav>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <div>
+        <h1 class="mb-2"><i class="fas fa-file-alt me-3"></i>Reports</h1>
+        <p class="text-muted mb-0">Generate contractor and project reports</p>
+    </div>
+</div>
+
+<div class="row mb-4">
+    <div class="col-md-4 mb-3">
+        <div class="quick-action-card primary" onclick="location.href='{% url 'dashboard:contractor_report' %}'">
+            <i class="fas fa-chart-bar quick-action-icon"></i>
+            <h5 class="mb-2">Contractor Summary</h5>
+            <p class="mb-0">Overall portfolio overview</p>
+        </div>
+    </div>
+</div>
+
+{% if projects %}
+<div class="card">
+    <div class="card-body">
+        <h5 class="card-title"><i class="fas fa-project-diagram me-2"></i>Project Reports</h5>
+        <div class="table-responsive">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Project</th>
+                        <th class="text-center">Customer Report</th>
+                        <th class="text-center">Job Report</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for project in projects %}
+                    <tr>
+                        <td>{{ project.name }}</td>
+                        <td class="text-center">
+                            <a href="{% url 'dashboard:customer_report' project.pk %}" class="btn btn-outline-primary btn-sm">
+                                <i class="fas fa-user me-1"></i>Customer
+                            </a>
+                        </td>
+                        <td class="text-center">
+                            <a href="{% url 'dashboard:contractor_job_report' project.pk %}" class="btn btn-outline-secondary btn-sm">
+                                <i class="fas fa-hard-hat me-1"></i>Job
+                            </a>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% else %}
+<div class="text-center text-muted">
+    <p>No active projects available.</p>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -496,3 +496,27 @@ class JobEntryOrderingTests(TestCase):
         self.assertEqual(
             [r["date"] for r in results], ["2024-01-10", "2024-01-01"]
         )
+
+
+class ReportsPageTests(TestCase):
+    def setUp(self):
+        self.contractor = Contractor.objects.create(
+            name="Test Contractor", email="user@example.com"
+        )
+        ContractorUser.objects.create_user(
+            email="user@example.com", password="secret", contractor=self.contractor
+        )
+        self.project = self.contractor.projects.create(
+            name="Proj", start_date="2024-01-01"
+        )
+
+    def test_reports_page_lists_project_links(self):
+        self.client.post(
+            reverse("login"), {"username": "user@example.com", "password": "secret"}
+        )
+        response = self.client.get(reverse("dashboard:reports"))
+        self.assertContains(response, "Project Reports")
+        self.assertContains(response, self.project.name)
+        self.assertContains(
+            response, reverse("dashboard:customer_report", args=[self.project.pk])
+        )

--- a/jobtracker/dashboard/urls.py
+++ b/jobtracker/dashboard/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('projects/<int:pk>/add-entry/', views.add_job_entry, name='add_job_entry'),
     path('entries/<int:pk>/edit/', views.edit_job_entry, name='edit_job_entry'),
     path('projects/<int:pk>/add-payment/', views.add_payment, name='add_payment'),
+    path('reports/', views.reports, name='reports'),
     path('reports/contractor/', views.contractor_report, name='contractor_report'),
     path('projects/<int:pk>/customer-report/', views.customer_report, name='customer_report'),
     path('projects/<int:pk>/contractor-report/', views.contractor_job_report, name='contractor_job_report'),

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -145,6 +145,24 @@ def project_list(request):
 
 
 @login_required
+def reports(request):
+    """Display available report links."""
+    contractor = getattr(request.user, "contractor", None)
+    if contractor is None:
+        return redirect("login")
+
+    projects = contractor.projects.filter(end_date__isnull=True)
+
+    return render(
+        request,
+        "dashboard/reports.html",
+        {
+            "projects": projects,
+        },
+    )
+
+
+@login_required
 def project_detail(request, pk):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:


### PR DESCRIPTION
## Summary
- Add dedicated reports index page listing contractor and project report links
- Update dashboard quick action and site navigation to point to new reports page
- Cover reports page with unit test

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b7335dd8cc83308a6e8e23740483bf