### PR TITLE
Display current timestamp on report pages

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
@@ -345,7 +345,7 @@ body {
 <div class="{% if report %}report-header{% else %}text-center mb-4{% endif %}">
     <h2>{{ contractor.name|default:contractor.email }}</h2>
     <h1>Contractor Job Report</h1>
-    <div class="project-info">{{ project.name }} • Generated {{ "now"|date:"F d, Y \\a\\t g:i A" }}</div>
+    <div class="project-info">{{ project.name }} • Generated {% now "F d, Y \\a\\t g:i A" %}</div>
 </div>
 
 <!-- Export Button -->
@@ -358,7 +358,7 @@ body {
             </a>
         </div>
         <div class="text-muted">
-            <small><i class="fas fa-info-circle me-1"></i>Report generated on {{ "now"|date:"F d, Y \\a\\t g:i A" }}</small>
+            <small><i class="fas fa-info-circle me-1"></i>Report generated on {% now "F d, Y \\a\\t g:i A" %}</small>
         </div>
     </div>
 </div>
@@ -541,8 +541,8 @@ body {
 {% if report %}
 <div class="report-footer">
     <div class="generation-info">
-        <strong>Report generated on {{ "now"|date:"F d, Y \a\t g:i A" }}</strong> | 
-        {{ contractor.name|default:contractor.email }} | 
+        <strong>Report generated on {% now "F d, Y \a\t g:i A" %}</strong> |
+        {{ contractor.name|default:contractor.email }} |
         Squire Enterprises Job Tracking System
     </div>
     <div class="confidential">

--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -546,7 +546,7 @@ body {
 <div class="{% if report %}report-header{% else %}text-center mb-4{% endif %}">
     <h1>Portfolio Summary Report</h1>
     <div class="contractor-info">{{ contractor.name|default:contractor.email }}</div>
-    <div class="report-period">Complete Business Analysis • Generated {{ "now"|date:"F d, Y \\a\\t g:i A" }}</div>
+    <div class="report-period">Complete Business Analysis • Generated {% now "F d, Y \\a\\t g:i A" %}</div>
 </div>
 
 <!-- Export Button -->
@@ -559,7 +559,7 @@ body {
             </a>
         </div>
         <div class="text-muted">
-            <small><i class="fas fa-info-circle me-1"></i>Report generated on {{ "now"|date:"F d, Y \\a\\t g:i A" }}</small>
+            <small><i class="fas fa-info-circle me-1"></i>Report generated on {% now "F d, Y \\a\\t g:i A" %}</small>
         </div>
     </div>
 </div>
@@ -939,7 +939,7 @@ body {
     <div class="footer-content">
         <div class="footer-section">
             <h5>Report Details</h5>
-            <p>Generated: {{ "now"|date:"F d, Y \a\t g:i A" }}</p>
+            <p>Generated: {% now "F d, Y \a\t g:i A" %}</p>
             <p>Report Type: Portfolio Summary</p>
             <p>Data Period: All Active Projects</p>
         </div>

--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -108,8 +108,8 @@
             <div class="d-flex align-items-center justify-content-center">
                 <i class="fas fa-sun fa-2x me-3"></i>
                 <div>
-                    <div class="fs-4 fw-bold">{{ "now"|date:"g:i A" }}</div>
-                    <div class="fs-5">{{ "now"|date:"l, F j" }}</div>
+                    <div class="fs-4 fw-bold">{% now "g:i A" %}</div>
+                    <div class="fs-5">{% now "l, F j" %}</div>
                     <small>Great day for productivity!</small>
                 </div>
             </div>

--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -488,7 +488,7 @@ body {
 <div class="{% if report %}report-header{% else %}text-center mb-4{% endif %}">
     <h2>{{ contractor.name|default:contractor.email }}</h2>
     <h1>Summary of Work</h1>
-    <div class="project-details">{{ project.name }} • {{ "now"|date:"F d, Y \\a\\t g:i A" }}</div>
+    <div class="project-details">{{ project.name }} • {% now "F d, Y \\a\\t g:i A" %}</div>
 </div>
 
 <!-- Export Button -->
@@ -501,7 +501,7 @@ body {
             </a>
         </div>
         <div class="text-muted">
-            <small><i class="fas fa-info-circle me-1"></i>Report generated on {{ "now"|date:"F d, Y \\a\\t g:i A" }}</small>
+            <small><i class="fas fa-info-circle me-1"></i>Report generated on {% now "F d, Y \\a\\t g:i A" %}</small>
         </div>
     </div>
 </div>
@@ -688,7 +688,7 @@ body {
 <div class="report-footer">
     <div class="thank-you">Thank you for your business!</div>
     <div class="generation-info">
-        <strong>Invoice generated on {{ "now"|date:"F d, Y \\a\\t g:i A" }}</strong>
+        <strong>Invoice generated on {% now "F d, Y \\a\\t g:i A" %}</strong>
     </div>
     <div class="company-info">
         {{ contractor.name|default:"Squire Enterprises" }} | Professional Services | 


### PR DESCRIPTION
## Summary
- use Django `now` tag to render current timestamp in contractor, customer, and job report templates
- ensure summary dashboard shows current date and time

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b73c3323d88330b0937a1fd5feea8c