### PR TITLE
Keep job entry summary sidebar below header

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -196,7 +196,7 @@
     
     <!-- Summary Sidebar -->
     <div class="col-lg-3">
-        <div class="sticky-top" style="top: 100px;">
+        <div class="sticky-top" style="top: 100px; z-index: 900;">
             <!-- Daily Summary -->
             <div class="card mb-3">
                 <div class="card-header bg-success text-white text-center">


### PR DESCRIPTION
## Summary
- Ensure summary sidebar on job entry form sits beneath the navigation header to prevent link overlap

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b740587074833087ebcc052220c0e0