### PR TITLE
Set timezone to Eastern Standard Time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM python:3.12-slim
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+ENV TZ=America/New_York
+
+# Install system packages
+RUN apt-get update && apt-get install -y --no-install-recommends tzdata && rm -rf /var/lib/apt/lists/*
 
 # Install dependencies
 WORKDIR /app

--- a/jobtracker/jobtracker/settings.py
+++ b/jobtracker/jobtracker/settings.py
@@ -92,7 +92,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/New_York'
 USE_I18N = True
 USE_TZ = True
 

--- a/render.yaml
+++ b/render.yaml
@@ -29,6 +29,8 @@ services:
         value: "https://*.onrender.com,https://app.squire.enterprises"
       - key: MEDIA_ROOT
         value: /var/media
+      - key: TZ
+        value: America/New_York
 databases:
   - name: jobtracker-db
     plan: free


### PR DESCRIPTION
## Summary
- Configure Django project to use the America/New_York timezone
- Set container timezone and install tzdata
- Propagate timezone through Render deployment configuration

## Testing
- `python jobtracker/manage.py test`
- `python jobtracker/manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68b742986d60833084e882a04e79d62b