### PR TITLE
Support selecting project before logging job entry or payment

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -17,14 +17,14 @@
 <!-- Quick Actions -->
 <div class="row mb-4">
     <div class="col-md-3 mb-3">
-        <div class="quick-action-card primary" onclick="location.href='{% if first_project %}{% url 'dashboard:add_job_entry' first_project.pk %}{% else %}{% url 'dashboard:project_list' %}{% endif %}'">
+        <div class="quick-action-card primary" onclick="location.href='{% url 'dashboard:select_job_entry_project' %}'">
             <i class="fas fa-plus-circle quick-action-icon"></i>
             <h5 class="mb-2">New Job Entry</h5>
             <p class="mb-0">Log today's work</p>
         </div>
     </div>
     <div class="col-md-3 mb-3">
-        <div class="quick-action-card success" onclick="location.href='{% if first_project %}{% url 'dashboard:add_payment' first_project.pk %}{% else %}{% url 'dashboard:project_list' %}{% endif %}'">
+        <div class="quick-action-card success" onclick="location.href='{% url 'dashboard:select_payment_project' %}'">
             <i class="fas fa-money-bill-wave quick-action-icon"></i>
             <h5 class="mb-2">Record Payment</h5>
             <p class="mb-0">Track incoming payments</p>
@@ -86,11 +86,11 @@
                     </a>
                     
                     {% if first_project %}
-                    <a href="{% url 'dashboard:add_job_entry' first_project.pk %}" class="btn btn-success">
+                    <a href="{% url 'dashboard:select_job_entry_project' %}" class="btn btn-success">
                         <i class="fas fa-plus-circle me-2"></i>Quick Entry
                     </a>
                     
-                    <a href="{% url 'dashboard:add_payment' first_project.pk %}" class="btn btn-warning">
+                    <a href="{% url 'dashboard:select_payment_project' %}" class="btn btn-warning">
                         <i class="fas fa-money-bill-wave me-2"></i>Add Payment
                     </a>
                     {% endif %}
@@ -346,13 +346,13 @@ document.addEventListener('DOMContentLoaded', function() {
                 case 'n':
                     e.preventDefault();
                     {% if first_project %}
-                    window.location.href = '{% url "dashboard:add_job_entry" first_project.pk %}';
+                    window.location.href = '{% url "dashboard:select_job_entry_project" %}';
                     {% endif %}
                     break;
                 case 'p':
                     e.preventDefault();
                     {% if first_project %}
-                    window.location.href = '{% url "dashboard:add_payment" first_project.pk %}';
+                    window.location.href = '{% url "dashboard:select_payment_project" %}';
                     {% endif %}
                     break;
                 case 'r':

--- a/jobtracker/dashboard/templates/dashboard/select_project.html
+++ b/jobtracker/dashboard/templates/dashboard/select_project.html
@@ -1,0 +1,124 @@
+{% extends 'dashboard/base.html' %}
+{% load humanize %}
+{% block title %}Select Project{% endblock %}
+{% block content %}
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0">
+        <i class="fas fa-project-diagram me-3"></i>{{ page_title|default:"Select Project" }}
+    </h1>
+</div>
+
+{% if projects %}
+<div class="row">
+    {% for project in projects %}
+    <div class="col-lg-4 col-md-6 mb-4">
+        <div class="card h-100 project-card selectable-card"
+             role="button"
+             onclick="location.href='{% url action_url_name project.pk %}'">
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-start mb-3">
+                        <h5 class="card-title mb-0">{{ project.name }}</h5>
+                        <span class="badge bg-success">
+                            <i class="fas fa-play me-1"></i>Active
+                        </span>
+                    </div>
+
+                    <div class="d-flex text-center mb-3">
+                        <div class="flex-fill border-end px-2">
+                            <div class="text-primary fw-bold">${{ project.total_billable|floatformat:0|intcomma }}</div>
+                            <small class="text-muted text-nowrap">Billable</small>
+                        </div>
+                        <div class="flex-fill border-end px-2">
+                            <div class="text-success fw-bold">${{ project.total_payments|floatformat:0|intcomma }}</div>
+                            <small class="text-muted text-nowrap">Paid</small>
+                        </div>
+                        <div class="flex-fill px-2">
+                            <div class="{% if project.outstanding > 0 %}text-warning{% else %}text-success{% endif %} fw-bold">
+                                ${{ project.outstanding|floatformat:0|intcomma }}
+                            </div>
+                            <small class="text-muted text-nowrap">Outstanding</small>
+                        </div>
+                    </div>
+
+                    <div class="progress mb-3" style="height: 6px;">
+                        {% widthratio project.total_payments project.total_billable 100 as percentage %}
+                        <div class="progress-bar bg-success" role="progressbar"
+                             style="width: {{ percentage|default:0 }}%"
+                             aria-valuenow="{{ percentage|default:0 }}"
+                             aria-valuemin="0" aria-valuemax="100">
+                        </div>
+                    </div>
+                </div>
+                <div class="card-footer bg-transparent">
+                    <small class="text-muted">
+                        <i class="fas fa-calendar me-1"></i>Started {{ project.start_date|date:"M d, Y" }}
+                    </small>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% else %}
+<!-- Empty State -->
+<div class="text-center py-5">
+    <div class="card">
+        <div class="card-body py-5">
+            <i class="fas fa-folder-open fa-4x text-muted mb-4"></i>
+            <h3 class="text-muted mb-3">No Projects Found</h3>
+            <p class="text-muted mb-4">
+                You don't have any active projects yet. Get started by creating your first project.
+            </p>
+            {% if user.is_staff %}
+            <a href="{% url 'admin:tracker_project_add' %}" class="btn btn-primary btn-lg">
+                <i class="fas fa-plus me-2"></i>Create Your First Project
+            </a>
+            {% else %}
+            <p class="text-muted">
+                Contact your administrator to create projects.
+            </p>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<style>
+.project-card {
+    transition: all 0.3s ease;
+    border: none;
+    box-shadow: var(--shadow-md);
+}
+
+.project-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-xl);
+}
+
+.selectable-card {
+    cursor: pointer;
+}
+
+.progress-bar {
+    transition: width 1s ease-in-out;
+}
+
+@media (max-width: 768px) {
+    .project-card .d-flex > .flex-fill {
+        border-right: none !important;
+        border-bottom: 1px solid var(--border-color);
+        padding-bottom: 1rem;
+        margin-bottom: 1rem;
+    }
+
+    .project-card .d-flex > .flex-fill:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+        margin-bottom: 0;
+    }
+}
+</style>
+
+{% endblock %}
+

--- a/jobtracker/dashboard/urls.py
+++ b/jobtracker/dashboard/urls.py
@@ -1,22 +1,47 @@
 from django.urls import path
 from . import views
 
-app_name = 'dashboard'
+app_name = "dashboard"
 
 urlpatterns = [
-    path('', views.contractor_summary, name='contractor_summary'),
-    path('projects/', views.project_list, name='project_list'),
-    path('projects/<int:pk>/', views.project_detail, name='project_detail'),
-    path('projects/<int:pk>/add-entry/', views.add_job_entry, name='add_job_entry'),
-    path('entries/<int:pk>/edit/', views.edit_job_entry, name='edit_job_entry'),
-    path('projects/<int:pk>/add-payment/', views.add_payment, name='add_payment'),
-    path('reports/', views.reports, name='reports'),
-    path('reports/contractor/', views.contractor_report, name='contractor_report'),
-    path('projects/<int:pk>/customer-report/', views.customer_report, name='customer_report'),
-    path('projects/<int:pk>/contractor-report/', views.contractor_job_report, name='contractor_job_report'),
-    
+    path("", views.contractor_summary, name="contractor_summary"),
+    path("projects/", views.project_list, name="project_list"),
+    path("projects/<int:pk>/", views.project_detail, name="project_detail"),
+    path(
+        "projects/add-entry/select/",
+        views.select_job_entry_project,
+        name="select_job_entry_project",
+    ),
+    path(
+        "projects/add-payment/select/",
+        views.select_payment_project,
+        name="select_payment_project",
+    ),
+    path("projects/<int:pk>/add-entry/", views.add_job_entry, name="add_job_entry"),
+    path("entries/<int:pk>/edit/", views.edit_job_entry, name="edit_job_entry"),
+    path("projects/<int:pk>/add-payment/", views.add_payment, name="add_payment"),
+    path("reports/", views.reports, name="reports"),
+    path("reports/contractor/", views.contractor_report, name="contractor_report"),
+    path(
+        "projects/<int:pk>/customer-report/",
+        views.customer_report,
+        name="customer_report",
+    ),
+    path(
+        "projects/<int:pk>/contractor-report/",
+        views.contractor_job_report,
+        name="contractor_job_report",
+    ),
     # New API endpoints
-    path('api/search-entries/', views.search_entries, name='search_entries'),
-    path('api/material-templates/', views.get_material_templates, name='material_templates'),
-    path('api/projects/<int:pk>/analytics/', views.project_analytics_data, name='project_analytics'),
+    path("api/search-entries/", views.search_entries, name="search_entries"),
+    path(
+        "api/material-templates/",
+        views.get_material_templates,
+        name="material_templates",
+    ),
+    path(
+        "api/projects/<int:pk>/analytics/",
+        views.project_analytics_data,
+        name="project_analytics",
+    ),
 ]

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -40,7 +40,7 @@ def contractor_summary(request):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    
+
     projects = contractor.projects.filter(end_date__isnull=True).prefetch_related(
         "job_entries", "payments"
     )
@@ -49,29 +49,37 @@ def contractor_summary(request):
         p.total_payments = sum((pay.amount or 0) for pay in p.payments.all())
         p.outstanding = p.total_billable - p.total_payments
     first_project = projects.first()
-    
+
     overall_billable = (
-        JobEntry.objects.filter(project__contractor=contractor, project__end_date__isnull=True)
+        JobEntry.objects.filter(
+            project__contractor=contractor, project__end_date__isnull=True
+        )
         .aggregate(total=Sum("billable_amount"))
         .get("total")
         or 0
     )
     overall_payments = (
-        Payment.objects.filter(project__contractor=contractor, project__end_date__isnull=True)
+        Payment.objects.filter(
+            project__contractor=contractor, project__end_date__isnull=True
+        )
         .aggregate(total=Sum("amount"))
         .get("total")
         or 0
     )
     outstanding = overall_billable - overall_payments
-    
+
     # Recent activity for dashboard
-    recent_entries = JobEntry.objects.filter(
-        project__contractor=contractor
-    ).select_related('project', 'asset', 'employee').order_by('-date')[:5]
-    
-    recent_payments = Payment.objects.filter(
-        project__contractor=contractor
-    ).select_related('project').order_by('-date')[:5]
+    recent_entries = (
+        JobEntry.objects.filter(project__contractor=contractor)
+        .select_related("project", "asset", "employee")
+        .order_by("-date")[:5]
+    )
+
+    recent_payments = (
+        Payment.objects.filter(project__contractor=contractor)
+        .select_related("project")
+        .order_by("-date")[:5]
+    )
 
     current_hour = timezone.localtime().hour
     if current_hour < 12:
@@ -83,18 +91,18 @@ def contractor_summary(request):
 
     return render(
         request,
-        'dashboard/contractor_summary.html',
+        "dashboard/contractor_summary.html",
         {
-            'projects': projects,
-            'first_project': first_project,
-            'overall_billable': overall_billable,
-            'overall_payments': overall_payments,
-            'outstanding': outstanding,
-            'contractor': contractor,
-            'contractor_logo_url': contractor.logo.url if contractor.logo else None,
-            'recent_entries': recent_entries,
-            'recent_payments': recent_payments,
-            'greeting': greeting,
+            "projects": projects,
+            "first_project": first_project,
+            "overall_billable": overall_billable,
+            "overall_payments": overall_payments,
+            "outstanding": outstanding,
+            "contractor": contractor,
+            "contractor_logo_url": contractor.logo.url if contractor.logo else None,
+            "recent_entries": recent_entries,
+            "recent_payments": recent_payments,
+            "greeting": greeting,
         },
     )
 
@@ -104,42 +112,40 @@ def project_list(request):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    
+
     # Search functionality
-    search_query = request.GET.get('search', '')
+    search_query = request.GET.get("search", "")
     projects = contractor.projects.filter(end_date__isnull=True).prefetch_related(
         "job_entries", "payments"
     )
-    
+
     if search_query:
         projects = projects.filter(
-            Q(name__icontains=search_query) |
-            Q(job_entries__description__icontains=search_query)
+            Q(name__icontains=search_query)
+            | Q(job_entries__description__icontains=search_query)
         ).distinct()
-    
+
     total_billable = Decimal("0")
     total_payments = Decimal("0")
-    
+
     for p in projects:
-        p.total_billable = sum(
-            (je.billable_amount or 0) for je in p.job_entries.all()
-        )
+        p.total_billable = sum((je.billable_amount or 0) for je in p.job_entries.all())
         p.total_payments = sum((pay.amount or 0) for pay in p.payments.all())
         p.outstanding = p.total_billable - p.total_payments
         total_billable += Decimal(p.total_billable)
         total_payments += Decimal(p.total_payments)
-    
+
     total_outstanding = total_billable - total_payments
-    
+
     return render(
         request,
-        'dashboard/project_list.html',
+        "dashboard/project_list.html",
         {
-            'projects': projects,
-            'total_billable': total_billable,
-            'total_payments': total_payments,
-            'total_outstanding': total_outstanding,
-            'search_query': search_query,
+            "projects": projects,
+            "total_billable": total_billable,
+            "total_payments": total_payments,
+            "total_outstanding": total_outstanding,
+            "search_query": search_query,
         },
     )
 
@@ -151,7 +157,14 @@ def reports(request):
     if contractor is None:
         return redirect("login")
 
-    projects = contractor.projects.filter(end_date__isnull=True)
+    projects = contractor.projects.filter(end_date__isnull=True).prefetch_related(
+        "job_entries", "payments"
+    )
+
+    for p in projects:
+        p.total_billable = sum((je.billable_amount or 0) for je in p.job_entries.all())
+        p.total_payments = sum((pay.amount or 0) for pay in p.payments.all())
+        p.outstanding = p.total_billable - p.total_payments
 
     return render(
         request,
@@ -167,81 +180,147 @@ def project_detail(request, pk):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    
+
     project = get_object_or_404(Project, pk=pk, contractor=contractor)
-    
+
     # Get filter parameters
-    entry_filter = request.GET.get('filter', 'all')
-    search_query = request.GET.get('search', '')
-    
+    entry_filter = request.GET.get("filter", "all")
+    search_query = request.GET.get("search", "")
+
     # Base queryset for job entries
-    job_entries = project.job_entries.select_related('asset', 'employee').order_by('-date')
-    
+    job_entries = project.job_entries.select_related("asset", "employee").order_by(
+        "-date"
+    )
+
     # Apply filters
-    if entry_filter == 'labor':
+    if entry_filter == "labor":
         job_entries = job_entries.filter(employee__isnull=False)
-    elif entry_filter == 'equipment':
+    elif entry_filter == "equipment":
         job_entries = job_entries.filter(asset__isnull=False)
-    elif entry_filter == 'materials':
-        job_entries = job_entries.exclude(material_description='')
-    
+    elif entry_filter == "materials":
+        job_entries = job_entries.exclude(material_description="")
+
     # Apply search
     if search_query:
         job_entries = job_entries.filter(
-            Q(description__icontains=search_query) |
-            Q(material_description__icontains=search_query) |
-            Q(asset__name__icontains=search_query) |
-            Q(employee__name__icontains=search_query)
+            Q(description__icontains=search_query)
+            | Q(material_description__icontains=search_query)
+            | Q(asset__name__icontains=search_query)
+            | Q(employee__name__icontains=search_query)
         )
-    
-    payments = project.payments.all().order_by('-date')
-    
+
+    payments = project.payments.all().order_by("-date")
+
     # Calculate totals
-    total_billable = job_entries.aggregate(total=Sum('billable_amount'))['total'] or 0
-    total_payments = payments.aggregate(total=Sum('amount'))['total'] or 0
+    total_billable = job_entries.aggregate(total=Sum("billable_amount"))["total"] or 0
+    total_payments = payments.aggregate(total=Sum("amount"))["total"] or 0
     outstanding = total_billable - total_payments
-    
+
     # Analytics data
-    total_cost = job_entries.aggregate(total=Sum('cost_amount'))['total'] or 0
+    total_cost = job_entries.aggregate(total=Sum("cost_amount"))["total"] or 0
     profit = total_billable - total_cost
     margin = (profit / total_billable * 100) if total_billable > 0 else 0
-    
+
     # Weekly breakdown for analytics
     weekly_data = []
     for week in range(4):  # Last 4 weeks
-        start_date = timezone.now().date() - timedelta(weeks=week+1)
+        start_date = timezone.now().date() - timedelta(weeks=week + 1)
         end_date = start_date + timedelta(days=6)
-        
+
         week_entries = job_entries.filter(date__range=[start_date, end_date])
-        week_hours = week_entries.aggregate(hours=Sum('hours'))['hours'] or 0
-        week_billable = week_entries.aggregate(total=Sum('billable_amount'))['total'] or 0
-        week_cost = week_entries.aggregate(total=Sum('cost_amount'))['total'] or 0
-        
-        weekly_data.append({
-            'week': f"{start_date.strftime('%b %d')}-{end_date.strftime('%d')}",
-            'hours': week_hours,
-            'billable': week_billable,
-            'cost': week_cost,
-        })
-    
+        week_hours = week_entries.aggregate(hours=Sum("hours"))["hours"] or 0
+        week_billable = (
+            week_entries.aggregate(total=Sum("billable_amount"))["total"] or 0
+        )
+        week_cost = week_entries.aggregate(total=Sum("cost_amount"))["total"] or 0
+
+        weekly_data.append(
+            {
+                "week": f"{start_date.strftime('%b %d')}-{end_date.strftime('%d')}",
+                "hours": week_hours,
+                "billable": week_billable,
+                "cost": week_cost,
+            }
+        )
+
     weekly_data.reverse()  # Show oldest to newest
-    
+
     return render(
         request,
-        'dashboard/project_detail.html',
+        "dashboard/project_detail.html",
         {
-            'project': project,
-            'job_entries': job_entries[:20],  # Limit for performance
-            'payments': payments[:10],
-            'total_billable': total_billable,
-            'total_payments': total_payments,
-            'outstanding': outstanding,
-            'total_cost': total_cost,
-            'profit': profit,
-            'margin': margin,
-            'weekly_data': weekly_data,
-            'entry_filter': entry_filter,
-            'search_query': search_query,
+            "project": project,
+            "job_entries": job_entries[:20],  # Limit for performance
+            "payments": payments[:10],
+            "total_billable": total_billable,
+            "total_payments": total_payments,
+            "outstanding": outstanding,
+            "total_cost": total_cost,
+            "profit": profit,
+            "margin": margin,
+            "weekly_data": weekly_data,
+            "entry_filter": entry_filter,
+            "search_query": search_query,
+        },
+    )
+
+
+@login_required
+def select_job_entry_project(request):
+    contractor = getattr(request.user, "contractor", None)
+    if contractor is None:
+        return redirect("login")
+
+    projects = contractor.projects.filter(end_date__isnull=True).prefetch_related(
+        "job_entries", "payments"
+    )
+
+    for p in projects:
+        p.total_billable = sum((je.billable_amount or 0) for je in p.job_entries.all())
+        p.total_payments = sum((pay.amount or 0) for pay in p.payments.all())
+        p.outstanding = p.total_billable - p.total_payments
+
+    if not projects.exists():
+        messages.info(request, "Please create a project before adding job entries.")
+        return redirect("dashboard:project_list")
+
+    return render(
+        request,
+        "dashboard/select_project.html",
+        {
+            "projects": projects,
+            "action_url_name": "dashboard:add_job_entry",
+            "page_title": "Select Project for Job Entry",
+        },
+    )
+
+
+@login_required
+def select_payment_project(request):
+    contractor = getattr(request.user, "contractor", None)
+    if contractor is None:
+        return redirect("login")
+
+    projects = contractor.projects.filter(end_date__isnull=True).prefetch_related(
+        "job_entries", "payments"
+    )
+
+    for p in projects:
+        p.total_billable = sum((je.billable_amount or 0) for je in p.job_entries.all())
+        p.total_payments = sum((pay.amount or 0) for pay in p.payments.all())
+        p.outstanding = p.total_billable - p.total_payments
+
+    if not projects.exists():
+        messages.info(request, "Please create a project before recording payments.")
+        return redirect("dashboard:project_list")
+
+    return render(
+        request,
+        "dashboard/select_project.html",
+        {
+            "projects": projects,
+            "action_url_name": "dashboard:add_payment",
+            "page_title": "Select Project for Payment",
         },
     )
 
@@ -251,7 +330,7 @@ def add_job_entry(request, pk):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    
+
     project = get_object_or_404(Project, pk=pk, contractor=contractor)
     assets = contractor.assets.all()
     employees = contractor.employees.all()
@@ -259,23 +338,27 @@ def add_job_entry(request, pk):
     if request.method == "POST":
         date = request.POST.get("date")
         entries_created = 0
-        
+
         # Process labor/equipment entries
         hours_list = request.POST.getlist("hours[]") or request.POST.getlist("hours")
         asset_ids = request.POST.getlist("asset[]") or request.POST.getlist("asset")
-        employee_ids = request.POST.getlist("employee[]") or request.POST.getlist("employee")
-        descriptions = request.POST.getlist("description[]") or request.POST.getlist("description")
+        employee_ids = request.POST.getlist("employee[]") or request.POST.getlist(
+            "employee"
+        )
+        descriptions = request.POST.getlist("description[]") or request.POST.getlist(
+            "description"
+        )
 
         # Create labor/equipment entries
         labor_entries = zip(hours_list, asset_ids, employee_ids, descriptions)
         for hours, asset_id, employee_id, desc in labor_entries:
             if not any([hours, asset_id, employee_id, desc]):
                 continue
-            
+
             asset = assets.filter(pk=asset_id).first() if asset_id else None
             employee = employees.filter(pk=employee_id).first() if employee_id else None
             hours_dec = Decimal(hours or 0)
-            
+
             if hours_dec > 0 or asset or employee:
                 JobEntry.objects.create(
                     project=project,
@@ -288,26 +371,31 @@ def add_job_entry(request, pk):
                     description=desc or "",
                 )
                 entries_created += 1
-        
+
         # Process materials entries
         material_descriptions = request.POST.getlist("material_description[]")
         material_quantities = request.POST.getlist("material_quantity[]")
         material_units = request.POST.getlist("material_unit[]")
         material_costs = request.POST.getlist("material_cost[]")
-        
+
         if material_descriptions:
-            materials = zip(material_descriptions, material_quantities, material_units, material_costs)
+            materials = zip(
+                material_descriptions,
+                material_quantities,
+                material_units,
+                material_costs,
+            )
             for desc, qty, unit, cost in materials:
                 if not any([desc, qty, cost]):
                     continue
-                
+
                 qty_dec = Decimal(qty or 0)
                 cost_dec = Decimal(cost or 0)
-                
+
                 if desc and qty_dec > 0 and cost_dec > 0:
                     # Create material entry with description including unit
                     full_desc = f"{desc} ({qty_dec} {unit})" if unit else desc
-                    
+
                     JobEntry.objects.create(
                         project=project,
                         date=date,
@@ -319,12 +407,17 @@ def add_job_entry(request, pk):
                         description=f"Material: {full_desc}",
                     )
                     entries_created += 1
-        
+
         if entries_created > 0:
-            messages.success(request, f"Successfully created {entries_created} job entries.")
+            messages.success(
+                request, f"Successfully created {entries_created} job entries."
+            )
         else:
-            messages.warning(request, "No entries were created. Please fill in at least one complete entry.")
-        
+            messages.warning(
+                request,
+                "No entries were created. Please fill in at least one complete entry.",
+            )
+
         return redirect("dashboard:project_detail", pk=project.pk)
 
     return render(
@@ -344,7 +437,7 @@ def edit_job_entry(request, pk):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    
+
     entry = get_object_or_404(JobEntry, pk=pk, project__contractor=contractor)
     assets = contractor.assets.all()
     employees = contractor.employees.all()
@@ -352,18 +445,20 @@ def edit_job_entry(request, pk):
     if request.method == "POST":
         entry.date = request.POST.get("date")
         entry.hours = Decimal(request.POST.get("hours") or 0)
-        
+
         asset_id = request.POST.get("asset")
         employee_id = request.POST.get("employee")
-        
+
         entry.asset = assets.filter(pk=asset_id).first() if asset_id else None
-        entry.employee = employees.filter(pk=employee_id).first() if employee_id else None
-        
+        entry.employee = (
+            employees.filter(pk=employee_id).first() if employee_id else None
+        )
+
         entry.material_description = request.POST.get("material_description", "")
         mat_cost = request.POST.get("material_cost")
         entry.material_cost = Decimal(mat_cost or 0) if mat_cost else None
         entry.description = request.POST.get("description", "")
-        
+
         entry.save()
         messages.success(request, "Job entry updated successfully.")
         return redirect("dashboard:project_detail", pk=entry.project.pk)
@@ -384,25 +479,24 @@ def add_payment(request, pk):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    
+
     project = get_object_or_404(Project, pk=pk, contractor=contractor)
 
     if request.method == "POST":
         date = request.POST.get("date")
         amount = Decimal(request.POST.get("amount") or 0)
         notes = request.POST.get("notes", "")
-        
+
         if amount > 0:
             Payment.objects.create(
-                project=project, 
-                amount=amount, 
-                date=date, 
-                notes=notes
+                project=project, amount=amount, date=date, notes=notes
             )
-            messages.success(request, f"Payment of ${amount:,.2f} recorded successfully.")
+            messages.success(
+                request, f"Payment of ${amount:,.2f} recorded successfully."
+            )
         else:
             messages.error(request, "Please enter a valid payment amount.")
-        
+
         return redirect("dashboard:project_detail", pk=project.pk)
 
     return render(
@@ -419,12 +513,12 @@ def contractor_report(request):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    
+
     projects_qs = contractor.projects.all().annotate(
         total_cost=Sum("job_entries__cost_amount"),
         total_billable=Sum("job_entries__billable_amount"),
     )
-    
+
     projects = []
     total_revenue = Decimal("0")
     total_cost = Decimal("0")
@@ -433,32 +527,32 @@ def contractor_report(request):
     profitable = 0
     breakeven = 0
     unprofitable = 0
-    
+
     for p in projects_qs.iterator():
         billable = p.total_billable or Decimal("0")
         cost = p.total_cost or Decimal("0")
         profit = billable - cost
         margin = (profit / billable * Decimal("100")) if billable else Decimal("0")
-        
+
         p.profit = profit
         p.margin = margin
         projects.append(p)
-        
+
         total_revenue += billable
         total_cost += cost
         total_profit += profit
         total_margin += margin
-        
+
         if profit > 100:
             profitable += 1
         elif profit >= 0:
             breakeven += 1
         else:
             unprofitable += 1
-    
+
     avg_margin = (total_margin / len(projects)) if projects else Decimal("0")
     roi = (total_profit / total_cost * Decimal("100")) if total_cost else None
-    
+
     export_pdf = request.GET.get("export") == "pdf"
     context = {
         "contractor": contractor,
@@ -473,14 +567,14 @@ def contractor_report(request):
         "breakeven_count": breakeven,
         "unprofitable_count": unprofitable,
     }
-    
+
     if export_pdf:
         pdf = _render_pdf(
             "dashboard/contractor_report.html", context, "contractor_summary_report.pdf"
         )
         if pdf:
             return pdf
-    
+
     return render(request, "dashboard/contractor_report.html", context)
 
 
@@ -489,15 +583,17 @@ def customer_report(request, pk):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    
+
     project = get_object_or_404(Project, pk=pk, contractor=contractor)
-    entries_qs = project.job_entries.select_related("asset", "employee").order_by("-date")
+    entries_qs = project.job_entries.select_related("asset", "employee").order_by(
+        "-date"
+    )
     entries = list(entries_qs)
     total = project.job_entries.aggregate(total=Sum("billable_amount"))["total"] or 0
     payments = list(project.payments.all())
     total_payments = project.payments.aggregate(total=Sum("amount"))["total"] or 0
     outstanding = total - (total_payments or 0)
-    
+
     export_pdf = request.GET.get("export") == "pdf"
 
     context = {
@@ -512,14 +608,14 @@ def customer_report(request, pk):
         "total_payments": total_payments or 0,
         "outstanding": outstanding,
     }
-    
+
     if export_pdf:
         pdf = _render_pdf(
             "dashboard/customer_report.html", context, "customer_report.pdf"
         )
         if pdf:
             return pdf
-    
+
     return render(request, "dashboard/customer_report.html", context)
 
 
@@ -528,34 +624,38 @@ def contractor_job_report(request, pk):
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
         return redirect("login")
-    
+
     project = get_object_or_404(Project, pk=pk, contractor=contractor)
-    entries_qs = project.job_entries.select_related("asset", "employee").order_by("-date")
+    entries_qs = project.job_entries.select_related("asset", "employee").order_by(
+        "-date"
+    )
     entries = []
     total_billable = Decimal("0")
     total_cost = Decimal("0")
-    
+
     for e in entries_qs.iterator():
         billable = e.billable_amount or Decimal("0")
         cost = e.cost_amount or Decimal("0")
         profit = billable - cost
         margin = (profit / billable * Decimal("100")) if billable else Decimal("0")
-        
+
         e.profit = profit
         e.margin = margin
         entries.append(e)
         total_billable += billable
         total_cost += cost
-    
+
     total_profit = total_billable - total_cost
     overall_margin = (
-        (total_profit / total_billable) * Decimal("100") if total_billable else Decimal("0")
+        (total_profit / total_billable) * Decimal("100")
+        if total_billable
+        else Decimal("0")
     )
-    
+
     payments = list(project.payments.all())
     total_payments = project.payments.aggregate(total=Sum("amount"))["total"] or 0
     outstanding = total_billable - (total_payments or 0)
-    
+
     export_pdf = request.GET.get("export") == "pdf"
 
     context = {
@@ -573,14 +673,14 @@ def contractor_job_report(request, pk):
         "colspan_before_total": 6,
         "total_columns": 10,
     }
-    
+
     if export_pdf:
         pdf = _render_pdf(
             "dashboard/contractor_job_report.html", context, "contractor_job_report.pdf"
         )
         if pdf:
             return pdf
-    
+
     return render(request, "dashboard/contractor_job_report.html", context)
 
 
@@ -590,37 +690,39 @@ def search_entries(request):
     """API endpoint for searching entries"""
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
-        return JsonResponse({'error': 'Unauthorized'}, status=401)
-    
-    query = request.GET.get('q', '')
-    project_id = request.GET.get('project_id')
-    
+        return JsonResponse({"error": "Unauthorized"}, status=401)
+
+    query = request.GET.get("q", "")
+    project_id = request.GET.get("project_id")
+
     entries = JobEntry.objects.filter(project__contractor=contractor)
-    
+
     if project_id:
         entries = entries.filter(project_id=project_id)
-    
+
     if query:
         entries = entries.filter(
-            Q(description__icontains=query) |
-            Q(material_description__icontains=query) |
-            Q(asset__name__icontains=query) |
-            Q(employee__name__icontains=query)
+            Q(description__icontains=query)
+            | Q(material_description__icontains=query)
+            | Q(asset__name__icontains=query)
+            | Q(employee__name__icontains=query)
         )
 
-    entries = entries.order_by('-date')
-    
+    entries = entries.order_by("-date")
+
     results = []
     for entry in entries[:10]:  # Limit results
-        results.append({
-            'id': entry.id,
-            'date': entry.date.strftime('%Y-%m-%d'),
-            'description': entry.description,
-            'amount': str(entry.billable_amount),
-            'project': entry.project.name,
-        })
-    
-    return JsonResponse({'results': results})
+        results.append(
+            {
+                "id": entry.id,
+                "date": entry.date.strftime("%Y-%m-%d"),
+                "description": entry.description,
+                "amount": str(entry.billable_amount),
+                "project": entry.project.name,
+            }
+        )
+
+    return JsonResponse({"results": results})
 
 
 @login_required
@@ -628,30 +730,60 @@ def get_material_templates(request):
     """API endpoint for material templates"""
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
-        return JsonResponse({'error': 'Unauthorized'}, status=401)
-    
+        return JsonResponse({"error": "Unauthorized"}, status=401)
+
     # This could be expanded to store actual templates in the database
     # For now, return some common templates
     templates = [
         {
-            'name': 'Office Supplies Basic',
-            'materials': [
-                {'description': 'Office Supplies - Basic', 'quantity': 1, 'unit': 'Each', 'cost': 25.00},
-                {'description': 'Printer Paper', 'quantity': 5, 'unit': 'Reams', 'cost': 8.50},
-                {'description': 'Writing Supplies', 'quantity': 1, 'unit': 'Set', 'cost': 15.00},
-            ]
+            "name": "Office Supplies Basic",
+            "materials": [
+                {
+                    "description": "Office Supplies - Basic",
+                    "quantity": 1,
+                    "unit": "Each",
+                    "cost": 25.00,
+                },
+                {
+                    "description": "Printer Paper",
+                    "quantity": 5,
+                    "unit": "Reams",
+                    "cost": 8.50,
+                },
+                {
+                    "description": "Writing Supplies",
+                    "quantity": 1,
+                    "unit": "Set",
+                    "cost": 15.00,
+                },
+            ],
         },
         {
-            'name': 'Basic Maintenance',
-            'materials': [
-                {'description': 'Cleaning Supplies', 'quantity': 1, 'unit': 'Each', 'cost': 15.00},
-                {'description': 'Safety Equipment', 'quantity': 1, 'unit': 'Each', 'cost': 45.00},
-                {'description': 'Maintenance Tools', 'quantity': 1, 'unit': 'Set', 'cost': 35.00},
-            ]
-        }
+            "name": "Basic Maintenance",
+            "materials": [
+                {
+                    "description": "Cleaning Supplies",
+                    "quantity": 1,
+                    "unit": "Each",
+                    "cost": 15.00,
+                },
+                {
+                    "description": "Safety Equipment",
+                    "quantity": 1,
+                    "unit": "Each",
+                    "cost": 45.00,
+                },
+                {
+                    "description": "Maintenance Tools",
+                    "quantity": 1,
+                    "unit": "Set",
+                    "cost": 35.00,
+                },
+            ],
+        },
     ]
-    
-    return JsonResponse({'templates': templates})
+
+    return JsonResponse({"templates": templates})
 
 
 @login_required
@@ -659,47 +791,71 @@ def project_analytics_data(request, pk):
     """API endpoint for project analytics data"""
     contractor = getattr(request.user, "contractor", None)
     if contractor is None:
-        return JsonResponse({'error': 'Unauthorized'}, status=401)
-    
+        return JsonResponse({"error": "Unauthorized"}, status=401)
+
     project = get_object_or_404(Project, pk=pk, contractor=contractor)
-    
+
     # Weekly breakdown
     weekly_data = []
     for week in range(8):  # Last 8 weeks
-        start_date = timezone.now().date() - timedelta(weeks=week+1)
+        start_date = timezone.now().date() - timedelta(weeks=week + 1)
         end_date = start_date + timedelta(days=6)
-        
+
         week_entries = project.job_entries.filter(date__range=[start_date, end_date])
-        week_hours = week_entries.aggregate(hours=Sum('hours'))['hours'] or 0
-        week_billable = week_entries.aggregate(total=Sum('billable_amount'))['total'] or 0
-        week_cost = week_entries.aggregate(total=Sum('cost_amount'))['total'] or 0
-        
-        weekly_data.append({
-            'week': f"{start_date.strftime('%b %d')}",
-            'hours': float(week_hours),
-            'billable': float(week_billable),
-            'cost': float(week_cost),
-        })
-    
+        week_hours = week_entries.aggregate(hours=Sum("hours"))["hours"] or 0
+        week_billable = (
+            week_entries.aggregate(total=Sum("billable_amount"))["total"] or 0
+        )
+        week_cost = week_entries.aggregate(total=Sum("cost_amount"))["total"] or 0
+
+        weekly_data.append(
+            {
+                "week": f"{start_date.strftime('%b %d')}",
+                "hours": float(week_hours),
+                "billable": float(week_billable),
+                "cost": float(week_cost),
+            }
+        )
+
     weekly_data.reverse()
-    
+
     # Category breakdown
-    labor_total = project.job_entries.filter(employee__isnull=False).aggregate(
-        total=Sum('billable_amount'))['total'] or 0
-    equipment_total = project.job_entries.filter(asset__isnull=False).aggregate(
-        total=Sum('billable_amount'))['total'] or 0
-    materials_total = project.job_entries.exclude(material_description='').aggregate(
-        total=Sum('billable_amount'))['total'] or 0
-    
-    return JsonResponse({
-        'weekly_data': weekly_data,
-        'category_breakdown': {
-            'labor': float(labor_total),
-            'equipment': float(equipment_total),
-            'materials': float(materials_total),
-        },
-        'totals': {
-            'billable': float(project.job_entries.aggregate(total=Sum('billable_amount'))['total'] or 0),
-            'cost': float(project.job_entries.aggregate(total=Sum('cost_amount'))['total'] or 0),
+    labor_total = (
+        project.job_entries.filter(employee__isnull=False).aggregate(
+            total=Sum("billable_amount")
+        )["total"]
+        or 0
+    )
+    equipment_total = (
+        project.job_entries.filter(asset__isnull=False).aggregate(
+            total=Sum("billable_amount")
+        )["total"]
+        or 0
+    )
+    materials_total = (
+        project.job_entries.exclude(material_description="").aggregate(
+            total=Sum("billable_amount")
+        )["total"]
+        or 0
+    )
+
+    return JsonResponse(
+        {
+            "weekly_data": weekly_data,
+            "category_breakdown": {
+                "labor": float(labor_total),
+                "equipment": float(equipment_total),
+                "materials": float(materials_total),
+            },
+            "totals": {
+                "billable": float(
+                    project.job_entries.aggregate(total=Sum("billable_amount"))["total"]
+                    or 0
+                ),
+                "cost": float(
+                    project.job_entries.aggregate(total=Sum("cost_amount"))["total"]
+                    or 0
+                ),
+            },
         }
-    })
+    )


### PR DESCRIPTION
## Summary
- restyle project selection page with project cards and shared template
- allow selecting project before recording a payment
- update dashboard shortcuts and buttons to use selection flow for payments
- compute and display project billable, paid, and outstanding totals in selection cards
- style project selection page with clickable project cards

## Testing
- `python jobtracker/manage.py test`
- `python -m black --check jobtracker/dashboard/urls.py jobtracker/dashboard/views.py`


------
https://chatgpt.com/codex/tasks/task_e_68b74578392c8330aface8cc34cf4589