### PR TITLE
Fix report timestamp formatting

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
@@ -345,7 +345,7 @@ body {
 <div class="{% if report %}report-header{% else %}text-center mb-4{% endif %}">
     <h2>{{ contractor.name|default:contractor.email }}</h2>
     <h1>Contractor Job Report</h1>
-    <div class="project-info">{{ project.name }} • Generated {% now "F d, Y \\a\\t g:i A" %}</div>
+    <div class="project-info">{{ project.name }} • Generated {% now "F d, Y" %} at {% now "g:i A" %}</div>
 </div>
 
 <!-- Export Button -->
@@ -358,7 +358,7 @@ body {
             </a>
         </div>
         <div class="text-muted">
-            <small><i class="fas fa-info-circle me-1"></i>Report generated on {% now "F d, Y \\a\\t g:i A" %}</small>
+            <small><i class="fas fa-info-circle me-1"></i>Report generated on {% now "F d, Y" %} at {% now "g:i A" %}</small>
         </div>
     </div>
 </div>
@@ -541,7 +541,7 @@ body {
 {% if report %}
 <div class="report-footer">
     <div class="generation-info">
-        <strong>Report generated on {% now "F d, Y \a\t g:i A" %}</strong> |
+        <strong>Report generated on {% now "F d, Y" %} at {% now "g:i A" %}</strong> |
         {{ contractor.name|default:contractor.email }} |
         Squire Enterprises Job Tracking System
     </div>

--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -546,7 +546,7 @@ body {
 <div class="{% if report %}report-header{% else %}text-center mb-4{% endif %}">
     <h1>Portfolio Summary Report</h1>
     <div class="contractor-info">{{ contractor.name|default:contractor.email }}</div>
-    <div class="report-period">Complete Business Analysis • Generated {% now "F d, Y \\a\\t g:i A" %}</div>
+    <div class="report-period">Complete Business Analysis • Generated {% now "F d, Y" %} at {% now "g:i A" %}</div>
 </div>
 
 <!-- Export Button -->
@@ -559,7 +559,7 @@ body {
             </a>
         </div>
         <div class="text-muted">
-            <small><i class="fas fa-info-circle me-1"></i>Report generated on {% now "F d, Y \\a\\t g:i A" %}</small>
+            <small><i class="fas fa-info-circle me-1"></i>Report generated on {% now "F d, Y" %} at {% now "g:i A" %}</small>
         </div>
     </div>
 </div>
@@ -939,7 +939,7 @@ body {
     <div class="footer-content">
         <div class="footer-section">
             <h5>Report Details</h5>
-            <p>Generated: {% now "F d, Y \a\t g:i A" %}</p>
+            <p>Generated: {% now "F d, Y" %} at {% now "g:i A" %}</p>
             <p>Report Type: Portfolio Summary</p>
             <p>Data Period: All Active Projects</p>
         </div>

--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -488,7 +488,7 @@ body {
 <div class="{% if report %}report-header{% else %}text-center mb-4{% endif %}">
     <h2>{{ contractor.name|default:contractor.email }}</h2>
     <h1>Summary of Work</h1>
-    <div class="project-details">{{ project.name }} • {% now "F d, Y \\a\\t g:i A" %}</div>
+    <div class="project-details">{{ project.name }} • {% now "F d, Y" %} at {% now "g:i A" %}</div>
 </div>
 
 <!-- Export Button -->
@@ -501,7 +501,7 @@ body {
             </a>
         </div>
         <div class="text-muted">
-            <small><i class="fas fa-info-circle me-1"></i>Report generated on {% now "F d, Y \\a\\t g:i A" %}</small>
+            <small><i class="fas fa-info-circle me-1"></i>Report generated on {% now "F d, Y" %} at {% now "g:i A" %}</small>
         </div>
     </div>
 </div>
@@ -688,7 +688,7 @@ body {
 <div class="report-footer">
     <div class="thank-you">Thank you for your business!</div>
     <div class="generation-info">
-        <strong>Invoice generated on {% now "F d, Y \\a\\t g:i A" %}</strong>
+        <strong>Invoice generated on {% now "F d, Y" %} at {% now "g:i A" %}</strong>
     </div>
     <div class="company-info">
         {{ contractor.name|default:"Squire Enterprises" }} | Professional Services | 


### PR DESCRIPTION
## Summary
- render date and time separately in report templates to avoid stray backslashes in timestamps

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7502770688330860612f42cb85180