### PR TITLE
Hide breadcrumb on reports page

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/reports.html
+++ b/jobtracker/dashboard/templates/dashboard/reports.html
@@ -3,13 +3,6 @@
 {% block title %}Reports{% endblock %}
 {% block content %}
 
-<nav aria-label="breadcrumb" class="mb-3">
-    <ol class="breadcrumb breadcrumb-custom">
-        <li class="breadcrumb-item"><a href="{% url 'dashboard:contractor_summary' %}"><i class="fas fa-home me-1"></i>Dashboard</a></li>
-        <li class="breadcrumb-item active">Reports</li>
-    </ol>
-</nav>
-
 <div class="d-flex justify-content-between align-items-center mb-4">
     <div>
         <h1 class="mb-2"><i class="fas fa-file-alt me-3"></i>Reports</h1>

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -520,3 +520,10 @@ class ReportsPageTests(TestCase):
         self.assertContains(
             response, reverse("dashboard:customer_report", args=[self.project.pk])
         )
+
+    def test_reports_page_has_no_breadcrumb(self):
+        self.client.post(
+            reverse("login"), {"username": "user@example.com", "password": "secret"}
+        )
+        response = self.client.get(reverse("dashboard:reports"))
+        self.assertNotContains(response, '<nav aria-label="breadcrumb"')


### PR DESCRIPTION
## Summary
- remove breadcrumb navigation from reports page template
- add regression test ensuring reports page renders without breadcrumb

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b753b960e08330890137304ff37f46