### PR TITLE
Add billable comparison to project analytics

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -460,22 +460,46 @@
                     <div class="col-md-6">
                         <div class="card h-100">
                             <div class="card-body">
-                                <h6 class="card-title">Cost Breakdown</h6>
-                                <div class="progress mb-2" style="height: 25px;">
-                                    <div class="progress-bar bg-primary" style="width: {{ labor_percent|floatformat:0 }}%;" title="Labor">
-                                        Labor {{ labor_percent|floatformat:0 }}%
+                                <h6 class="card-title">Project Breakdown</h6>
+                                <div class="mb-3">
+                                    <div class="small fw-semibold">Cost</div>
+                                    <div class="progress mb-1" style="height: 15px;">
+                                        <div class="progress-bar bg-primary" style="width: {{ labor_percent|floatformat:0 }}%;" title="Labor">
+                                            Labor {{ labor_percent|floatformat:0 }}%
+                                        </div>
+                                        <div class="progress-bar bg-warning" style="width: {{ equipment_percent|floatformat:0 }}%;" title="Equipment">
+                                            Equipment {{ equipment_percent|floatformat:0 }}%
+                                        </div>
+                                        <div class="progress-bar bg-secondary" style="width: {{ material_percent|floatformat:0 }}%;" title="Materials">
+                                            Materials {{ material_percent|floatformat:0 }}%
+                                        </div>
                                     </div>
-                                    <div class="progress-bar bg-warning" style="width: {{ equipment_percent|floatformat:0 }}%;" title="Equipment">
-                                        Equipment {{ equipment_percent|floatformat:0 }}%
-                                    </div>
-                                    <div class="progress-bar bg-secondary" style="width: {{ material_percent|floatformat:0 }}%;" title="Materials">
-                                        Materials {{ material_percent|floatformat:0 }}%
+                                    <div class="small text-muted">
+                                        Labor: ${{ labor_cost|floatformat:2|intcomma }} |
+                                        Equipment: ${{ equipment_cost|floatformat:2|intcomma }} |
+                                        Materials: ${{ material_cost|floatformat:2|intcomma }} |
+                                        Total: ${{ total_cost|floatformat:2|intcomma }}
                                     </div>
                                 </div>
-                                <div class="small text-muted">
-                                    <div>Labor: ${{ labor_cost|floatformat:2|intcomma }}</div>
-                                    <div>Equipment: ${{ equipment_cost|floatformat:2|intcomma }}</div>
-                                    <div>Materials: ${{ material_cost|floatformat:2|intcomma }}</div>
+                                <div>
+                                    <div class="small fw-semibold">Billable</div>
+                                    <div class="progress mb-1" style="height: 15px;">
+                                        <div class="progress-bar bg-primary" style="width: {{ billable_labor_percent|floatformat:0 }}%;" title="Labor">
+                                            Labor {{ billable_labor_percent|floatformat:0 }}%
+                                        </div>
+                                        <div class="progress-bar bg-warning" style="width: {{ billable_equipment_percent|floatformat:0 }}%;" title="Equipment">
+                                            Equipment {{ billable_equipment_percent|floatformat:0 }}%
+                                        </div>
+                                        <div class="progress-bar bg-secondary" style="width: {{ billable_material_percent|floatformat:0 }}%;" title="Materials">
+                                            Materials {{ billable_material_percent|floatformat:0 }}%
+                                        </div>
+                                    </div>
+                                    <div class="small text-muted">
+                                        Labor: ${{ billable_labor|floatformat:2|intcomma }} |
+                                        Equipment: ${{ billable_equipment|floatformat:2|intcomma }} |
+                                        Materials: ${{ billable_material|floatformat:2|intcomma }} |
+                                        Total: ${{ total_billable|floatformat:2|intcomma }}
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.db.models import Sum, Count, Q, F, ExpressionWrapper, DecimalField
+from django.db.models import Sum, Count, Q, F, ExpressionWrapper, DecimalField, Value
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import get_template
@@ -257,6 +257,52 @@ def project_detail(request, pk):
     else:
         labor_percent = equipment_percent = material_percent = 0
 
+    # Billable breakdown
+    billable_labor = job_entries.filter(employee__isnull=False).aggregate(
+        total=Sum(
+            ExpressionWrapper(
+                F("employee__billable_rate") * F("hours"),
+                output_field=DecimalField(max_digits=10, decimal_places=2),
+            )
+        )
+    )["total"] or Decimal("0")
+
+    billable_equipment = job_entries.filter(asset__isnull=False).aggregate(
+        total=Sum(
+            ExpressionWrapper(
+                F("asset__billable_rate") * F("hours"),
+                output_field=DecimalField(max_digits=10, decimal_places=2),
+            )
+        )
+    )["total"] or Decimal("0")
+
+    contractor_margin = getattr(project.contractor, "material_margin", Decimal("0")) or Decimal("0")
+    material_margin = contractor_margin / Decimal("100")
+    margin_multiplier = Decimal("1") - material_margin
+    if margin_multiplier > 0:
+        billable_material = (
+            job_entries.exclude(material_cost__isnull=True)
+            .aggregate(
+                total=Sum(
+                    ExpressionWrapper(
+                        F("material_cost") * F("hours") / Value(margin_multiplier),
+                        output_field=DecimalField(max_digits=10, decimal_places=2),
+                    )
+                )
+            )
+            .get("total")
+            or Decimal("0")
+        )
+    else:
+        billable_material = Decimal("0")
+
+    if total_billable:
+        billable_labor_percent = (billable_labor / total_billable) * 100
+        billable_equipment_percent = (billable_equipment / total_billable) * 100
+        billable_material_percent = (billable_material / total_billable) * 100
+    else:
+        billable_labor_percent = billable_equipment_percent = billable_material_percent = 0
+
     # Weekly breakdown for analytics
     weekly_data = []
     for week in range(4):  # Last 4 weeks
@@ -300,6 +346,12 @@ def project_detail(request, pk):
             "labor_percent": labor_percent,
             "equipment_percent": equipment_percent,
             "material_percent": material_percent,
+            "billable_labor": billable_labor,
+            "billable_equipment": billable_equipment,
+            "billable_material": billable_material,
+            "billable_labor_percent": billable_labor_percent,
+            "billable_equipment_percent": billable_equipment_percent,
+            "billable_material_percent": billable_material_percent,
             "weekly_data": weekly_data,
             "entry_filter": entry_filter,
             "search_query": search_query,


### PR DESCRIPTION
## Summary
- Rename Cost Breakdown card to Project Breakdown and add cost total
- Add billable labor, equipment, and materials breakdown alongside cost breakdown
- Display billable and cost breakdowns in a single card for side-by-side comparison
- Guard against missing contractor material margin to prevent analytics crash

## Testing
- `python -m py_compile jobtracker/dashboard/views.py`
- `python jobtracker/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b75f546bc883308ccd46d687ef2c57