### PR TITLE
Add billable comparison to project analytics

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -460,22 +460,46 @@
                     <div class="col-md-6">
                         <div class="card h-100">
                             <div class="card-body">
-                                <h6 class="card-title">Cost Breakdown</h6>
-                                <div class="progress mb-2" style="height: 25px;">
-                                    <div class="progress-bar bg-primary" style="width: {{ labor_percent|floatformat:0 }}%;" title="Labor">
-                                        Labor {{ labor_percent|floatformat:0 }}%
+                                <h6 class="card-title">Project Breakdown</h6>
+                                <div class="mb-3">
+                                    <div class="small fw-semibold">Cost</div>
+                                    <div class="progress mb-1" style="height: 15px;">
+                                        <div class="progress-bar bg-primary" style="width: {{ labor_percent|floatformat:0 }}%;" title="Labor">
+                                            Labor {{ labor_percent|floatformat:0 }}%
+                                        </div>
+                                        <div class="progress-bar bg-warning" style="width: {{ equipment_percent|floatformat:0 }}%;" title="Equipment">
+                                            Equipment {{ equipment_percent|floatformat:0 }}%
+                                        </div>
+                                        <div class="progress-bar bg-secondary" style="width: {{ material_percent|floatformat:0 }}%;" title="Materials">
+                                            Materials {{ material_percent|floatformat:0 }}%
+                                        </div>
                                     </div>
-                                    <div class="progress-bar bg-warning" style="width: {{ equipment_percent|floatformat:0 }}%;" title="Equipment">
-                                        Equipment {{ equipment_percent|floatformat:0 }}%
-                                    </div>
-                                    <div class="progress-bar bg-secondary" style="width: {{ material_percent|floatformat:0 }}%;" title="Materials">
-                                        Materials {{ material_percent|floatformat:0 }}%
+                                    <div class="small text-muted">
+                                        Labor: ${{ labor_cost|floatformat:2|intcomma }} |
+                                        Equipment: ${{ equipment_cost|floatformat:2|intcomma }} |
+                                        Materials: ${{ material_cost|floatformat:2|intcomma }} |
+                                        Total: ${{ total_cost|floatformat:2|intcomma }}
                                     </div>
                                 </div>
-                                <div class="small text-muted">
-                                    <div>Labor: ${{ labor_cost|floatformat:2|intcomma }}</div>
-                                    <div>Equipment: ${{ equipment_cost|floatformat:2|intcomma }}</div>
-                                    <div>Materials: ${{ material_cost|floatformat:2|intcomma }}</div>
+                                <div>
+                                    <div class="small fw-semibold">Billable</div>
+                                    <div class="progress mb-1" style="height: 15px;">
+                                        <div class="progress-bar bg-primary" style="width: {{ billable_labor_percent|floatformat:0 }}%;" title="Labor">
+                                            Labor {{ billable_labor_percent|floatformat:0 }}%
+                                        </div>
+                                        <div class="progress-bar bg-warning" style="width: {{ billable_equipment_percent|floatformat:0 }}%;" title="Equipment">
+                                            Equipment {{ billable_equipment_percent|floatformat:0 }}%
+                                        </div>
+                                        <div class="progress-bar bg-secondary" style="width: {{ billable_material_percent|floatformat:0 }}%;" title="Materials">
+                                            Materials {{ billable_material_percent|floatformat:0 }}%
+                                        </div>
+                                    </div>
+                                    <div class="small text-muted">
+                                        Labor: ${{ billable_labor|floatformat:2|intcomma }} |
+                                        Equipment: ${{ billable_equipment|floatformat:2|intcomma }} |
+                                        Materials: ${{ billable_material|floatformat:2|intcomma }} |
+                                        Total: ${{ total_billable|floatformat:2|intcomma }}
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- Rename Cost Breakdown card to Project Breakdown and add cost total
- Add billable labor, equipment, and materials breakdown alongside cost breakdown
- Display billable and cost breakdowns in a single card for side-by-side comparison
- Guard against missing contractor material margin to prevent analytics crash
- Calculate cost and billable breakdowns in Python to avoid 500 errors on the projects page
- Add defensive decimal handling around analytics calculations to prevent crashes with unexpected data
- Gracefully handle invalid numeric values and compute weekly stats in Python to avoid 500 errors

## Testing
- `python -m py_compile jobtracker/dashboard/views.py`
- `python jobtracker/manage.py test dashboard`


------
https://chatgpt.com/codex/tasks/task_e_68b75f546bc883308ccd46d687ef2c57