### PR TITLE
Add equipment and materials analytics to project view

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -1124,7 +1124,7 @@
                                 <h6 class="section-title">Category Performance Analysis</h6>
                                 <p class="section-subtitle">Cost vs Revenue breakdown with profitability insights</p>
                             </div>
-                            
+
                             <!-- Labor Analysis -->
                             <div class="category-analysis-row mb-4">
                                 <div class="row">
@@ -1160,53 +1160,165 @@
                                                         <div class="metric-label">Profit</div>
                                                     </div>
                                                 </div>
+                                                <div class="col-sm-3">
+                                                    <div class="metric-box">
+                                                        {% if labor_cost > 0 %}
+                                                            {% widthratio billable_labor labor_cost 100 as labor_margin %}
+                                                            <div class="metric-value {% if labor_margin >= 150 %}text-success{% elif labor_margin >= 120 %}text-warning{% else %}text-danger{% endif %}">{{ labor_margin|add:"-100"|floatformat:0 }}%</div>
+                                                        {% else %}
+                                                            <div class="metric-value text-muted">—</div>
+                                                        {% endif %}
+                                                        <div class="metric-label">Margin</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="progress-comparison mt-2">
+                                            <div class="progress" style="height: 8px;">
+                                                {% if billable_labor > 0 %}
+                                                    <div class="progress-bar bg-danger" style="width: {{ labor_cost_percent|floatformat:0 }}%" title="Cost: {{ labor_cost_percent|floatformat:0 }}%"></div>
+                                                    <div class="progress-bar bg-success" style="width: {{ labor_profit_percent|floatformat:0 }}%" title="Profit: {{ labor_profit_percent|floatformat:0 }}%"></div>
+                                                {% endif %}
+                                            </div>
+                                                <div class="progress-labels d-flex justify-content-between mt-1">
+                                                    <small class="text-muted">Cost vs Revenue comparison</small>
+                                                    <small class="{% if labor_cost < billable_labor %}text-success{% else %}text-danger{% endif %}">
+                                                        {% if labor_cost < billable_labor %}Profitable{% else %}Loss{% endif %}
+                                                    </small>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
-                    
-                    <div class="col-md-6">
-                        <div class="recommendations-card h-100">
-                            <div class="recommendations-header">
-                                <h6 class="recommendations-title">
-                                    <i class="fas fa-rocket me-2 text-primary"></i>
-                                    Growth Opportunities
-                                </h6>
-                            </div>
-                            <div class="recommendations-content">
-                                {% if margin < 15 %}
-                                <div class="recommendation-item">
-                                    <div class="rec-priority high"></div>
-                                    <div class="rec-text">
-                                        <strong>Improve Margins:</strong> Consider raising rates or optimizing resource allocation to increase profitability.
-                                    </div>
                                 </div>
-                                {% endif %}
-                                
-                                {% if labor_cost > 0 %}
-                                    {% widthratio billable_labor labor_cost 100 as labor_efficiency %}
-                                    {% if labor_efficiency < 150 %}
-                                    <div class="recommendation-item">
-                                        <div class="rec-priority medium"></div>
-                                        <div class="rec-text">
-                                            <strong>Labor Optimization:</strong> Labor margins could be improved through better rate management or efficiency gains.
+                            </div>
+
+                            <!-- Equipment Analysis -->
+                            <div class="category-analysis-row mb-4">
+                                <div class="row">
+                                    <div class="col-md-4">
+                                        <div class="category-header">
+                                            <div class="category-icon bg-warning">
+                                                <i class="fas fa-tools"></i>
+                                            </div>
+                                            <div class="category-info">
+                                                <h6 class="category-name">Equipment</h6>
+                                                <p class="category-desc">Asset utilization & billing</p>
+                                            </div>
                                         </div>
                                     </div>
-                                    {% endif %}
-                                {% endif %}
-                                
-                                {% if equipment_cost > labor_cost %}
-                                <div class="recommendation-item">
-                                    <div class="rec-priority low"></div>
-                                    <div class="rec-text">
-                                        <strong>Equipment Focus:</strong> Heavy equipment usage - ensure optimal utilization and competitive billing rates.
+                                    <div class="col-md-8">
+                                        <div class="category-metrics">
+                                            <div class="row">
+                                                <div class="col-sm-3">
+                                                    <div class="metric-box">
+                                                        <div class="metric-value text-danger">${{ equipment_cost|floatformat:0|intcomma }}</div>
+                                                        <div class="metric-label">Cost</div>
+                                                    </div>
+                                                </div>
+                                                <div class="col-sm-3">
+                                                    <div class="metric-box">
+                                                        <div class="metric-value text-success">${{ billable_equipment|floatformat:0|intcomma }}</div>
+                                                        <div class="metric-label">Billed</div>
+                                                    </div>
+                                                </div>
+                                                <div class="col-sm-3">
+                                                    <div class="metric-box">
+                                                        <div class="metric-value text-primary">${{ equipment_profit|floatformat:0|intcomma }}</div>
+                                                        <div class="metric-label">Profit</div>
+                                                    </div>
+                                                </div>
+                                                <div class="col-sm-3">
+                                                    <div class="metric-box">
+                                                        {% if equipment_cost > 0 %}
+                                                            {% widthratio billable_equipment equipment_cost 100 as equipment_margin %}
+                                                            <div class="metric-value {% if equipment_margin >= 150 %}text-success{% elif equipment_margin >= 120 %}text-warning{% else %}text-danger{% endif %}">{{ equipment_margin|add:"-100"|floatformat:0 }}%</div>
+                                                        {% else %}
+                                                            <div class="metric-value text-muted">—</div>
+                                                        {% endif %}
+                                                        <div class="metric-label">Margin</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="progress-comparison mt-2">
+                                            <div class="progress" style="height: 8px;">
+                                                {% if billable_equipment > 0 %}
+                                                    <div class="progress-bar bg-danger" style="width: {{ equip_cost_percent|floatformat:0 }}%" title="Cost: {{ equip_cost_percent|floatformat:0 }}%"></div>
+                                                    <div class="progress-bar bg-success" style="width: {{ equip_profit_percent|floatformat:0 }}%" title="Profit: {{ equip_profit_percent|floatformat:0 }}%"></div>
+                                                {% endif %}
+                                            </div>
+                                                <div class="progress-labels d-flex justify-content-between mt-1">
+                                                    <small class="text-muted">Cost vs Revenue comparison</small>
+                                                    <small class="{% if equipment_cost < billable_equipment %}text-success{% else %}text-danger{% endif %}">
+                                                        {% if equipment_cost < billable_equipment %}Profitable{% else %}Loss{% endif %}
+                                                    </small>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                                {% endif %}
-                                
-                                <div class="recommendation-item">
-                                    <div class="rec-priority low"></div>
-                                    <div class="rec-text">
-                                        <strong>Future Planning:</strong> Use this project's data to refine estimates for similar future work.
+                            </div>
+
+                            <!-- Materials Analysis -->
+                            <div class="category-analysis-row mb-4">
+                                <div class="row">
+                                    <div class="col-md-4">
+                                        <div class="category-header">
+                                            <div class="category-icon bg-secondary">
+                                                <i class="fas fa-boxes"></i>
+                                            </div>
+                                            <div class="category-info">
+                                                <h6 class="category-name">Materials</h6>
+                                                <p class="category-desc">Material costs & markup</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-8">
+                                        <div class="category-metrics">
+                                            <div class="row">
+                                                <div class="col-sm-3">
+                                                    <div class="metric-box">
+                                                        <div class="metric-value text-danger">${{ material_cost|floatformat:0|intcomma }}</div>
+                                                        <div class="metric-label">Cost</div>
+                                                    </div>
+                                                </div>
+                                                <div class="col-sm-3">
+                                                    <div class="metric-box">
+                                                        <div class="metric-value text-success">${{ billable_material|floatformat:0|intcomma }}</div>
+                                                        <div class="metric-label">Billed</div>
+                                                    </div>
+                                                </div>
+                                                <div class="col-sm-3">
+                                                    <div class="metric-box">
+                                                        <div class="metric-value text-primary">${{ material_profit|floatformat:0|intcomma }}</div>
+                                                        <div class="metric-label">Profit</div>
+                                                    </div>
+                                                </div>
+                                                <div class="col-sm-3">
+                                                    <div class="metric-box">
+                                                        {% if material_cost > 0 %}
+                                                            {% widthratio billable_material material_cost 100 as material_margin %}
+                                                            <div class="metric-value {% if material_margin >= 125 %}text-success{% elif material_margin >= 110 %}text-warning{% else %}text-danger{% endif %}">{{ material_margin|add:"-100"|floatformat:0 }}%</div>
+                                                        {% else %}
+                                                            <div class="metric-value text-muted">—</div>
+                                                        {% endif %}
+                                                        <div class="metric-label">Markup</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="progress-comparison mt-2">
+                                            <div class="progress" style="height: 8px;">
+                                                {% if billable_material > 0 %}
+                                                    <div class="progress-bar bg-danger" style="width: {{ mat_cost_percent|floatformat:0 }}%" title="Cost: {{ mat_cost_percent|floatformat:0 }}%"></div>
+                                                    <div class="progress-bar bg-success" style="width: {{ mat_profit_percent|floatformat:0 }}%" title="Profit: {{ mat_profit_percent|floatformat:0 }}%"></div>
+                                                {% endif %}
+                                            </div>
+                                                <div class="progress-labels d-flex justify-content-between mt-1">
+                                                    <small class="text-muted">Cost vs Revenue comparison</small>
+                                                    <small class="{% if material_cost < billable_material %}text-success{% else %}text-danger{% endif %}">
+                                                        {% if material_cost < billable_material %}Profitable{% else %}Loss{% endif %}
+                                                    </small>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -1265,6 +1377,72 @@
                                             <div class="legend-color cost"></div>
                                             <span>Cost</span>
                                         </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <!-- Business Insights & Recommendations -->
+                <div class="row mb-4">
+                    <div class="col-md-6">
+                        <div class="insights-card h-100">
+                            <div class="insights-header">
+                                <h6 class="insights-title">
+                                    <i class="fas fa-lightbulb me-2 text-warning"></i>
+                                    Business Insights
+                                </h6>
+                            </div>
+                            <div class="insights-content">
+                                <div class="insight-item">
+                                    <div class="insight-icon">
+                                        <i class="fas {% if margin >= 20 %}fa-trophy text-success{% elif margin >= 10 %}fa-thumbs-up text-warning{% else %}fa-exclamation-triangle text-danger{% endif %}"></i>
+                                    </div>
+                                    <div class="insight-text">
+                                        <strong>Profitability:</strong>
+                                        {% if margin >= 20 %}
+                                            Excellent profit margin! Your pricing strategy is working well.
+                                        {% elif margin >= 10 %}
+                                            Good profit margin. Consider optimizing costs for better returns.
+                                        {% else %}
+                                            Low profit margin. Review pricing and cost management strategies.
+                                        {% endif %}
+                                    </div>
+                                </div>
+
+                                <div class="insight-item">
+                                    <div class="insight-icon">
+                                        {% if labor_cost > equipment_cost and labor_cost > material_cost %}
+                                            <i class="fas fa-users text-primary"></i>
+                                        {% elif equipment_cost > labor_cost and equipment_cost > material_cost %}
+                                            <i class="fas fa-cogs text-warning"></i>
+                                        {% else %}
+                                            <i class="fas fa-box text-secondary"></i>
+                                        {% endif %}
+                                    </div>
+                                    <div class="insight-text">
+                                        <strong>Cost Driver:</strong>
+                                        {% if labor_cost > equipment_cost and labor_cost > material_cost %}
+                                            Labor is your primary cost center ({{ labor_percent|floatformat:0 }}% of costs).
+                                        {% elif equipment_cost > labor_cost and equipment_cost > material_cost %}
+                                            Equipment costs dominate this project ({{ equipment_percent|floatformat:0 }}% of costs).
+                                        {% else %}
+                                            Materials represent the largest cost category ({{ material_percent|floatformat:0 }}% of costs).
+                                        {% endif %}
+                                    </div>
+                                </div>
+
+                                <div class="insight-item">
+                                    <div class="insight-icon">
+                                        <i class="fas fa-chart-line text-info"></i>
+                                    </div>
+                                    <div class="insight-text">
+                                        <strong>Efficiency:</strong>
+                                        {% if total_hours > 0 %}
+                                            Your average billing rate is ${{ avg_hourly_rate|floatformat:0 }}/hour across all categories.
+                                        {% else %}
+                                            No hours logged yet for efficiency calculation.
+                                        {% endif %}
                                     </div>
                                 </div>
                             </div>
@@ -1421,238 +1599,4 @@ function loadMoreEntries() {
 }
 </script>
 
-{% endblock %}                    <div class="metric-label">Profit</div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    <div class="metric-box">
-                                                        {% if labor_cost > 0 %}
-                                                            {% widthratio billable_labor labor_cost 100 as labor_margin %}
-                                                            <div class="metric-value {% if labor_margin >= 150 %}text-success{% elif labor_margin >= 120 %}text-warning{% else %}text-danger{% endif %}">
-                                                                {{ labor_margin|add:"-100"|floatformat:0 }}%
-                                                            </div>
-                                                        {% else %}
-                                                            <div class="metric-value text-muted">—</div>
-                                                        {% endif %}
-                                                        <div class="metric-label">Margin</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="progress-comparison mt-2">
-                                            <div class="progress" style="height: 8px;">
-                                                {% if billable_labor > 0 %}
-                                                    <div class="progress-bar bg-danger" style="width: {{ labor_cost_percent|floatformat:0 }}%" title="Cost: {{ labor_cost_percent|floatformat:0 }}%"></div>
-                                                    <div class="progress-bar bg-success" style="width: {{ labor_profit_percent|floatformat:0 }}%" title="Profit: {{ labor_profit_percent|floatformat:0 }}%"></div>
-                                                {% endif %}
-                                            </div>
-                                                <div class="progress-labels d-flex justify-content-between mt-1">
-                                                    <small class="text-muted">Cost vs Revenue comparison</small>
-                                                    <small class="{% if labor_cost < billable_labor %}text-success{% else %}text-danger{% endif %}">
-                                                        {% if labor_cost < billable_labor %}Profitable{% else %}Loss{% endif %}
-                                                    </small>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Equipment Analysis -->
-                            <div class="category-analysis-row mb-4">
-                                <div class="row">
-                                    <div class="col-md-4">
-                                        <div class="category-header">
-                                            <div class="category-icon bg-warning">
-                                                <i class="fas fa-tools"></i>
-                                            </div>
-                                            <div class="category-info">
-                                                <h6 class="category-name">Equipment</h6>
-                                                <p class="category-desc">Asset utilization & billing</p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="col-md-8">
-                                        <div class="category-metrics">
-                                            <div class="row">
-                                                <div class="col-sm-3">
-                                                    <div class="metric-box">
-                                                        <div class="metric-value text-danger">${{ equipment_cost|floatformat:0|intcomma }}</div>
-                                                        <div class="metric-label">Cost</div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    <div class="metric-box">
-                                                        <div class="metric-value text-success">${{ billable_equipment|floatformat:0|intcomma }}</div>
-                                                        <div class="metric-label">Billed</div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    <div class="metric-box">
-                                                        <div class="metric-value text-primary">${{ equipment_profit|floatformat:0|intcomma }}</div>
-                                                        <div class="metric-label">Profit</div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    <div class="metric-box">
-                                                        {% if equipment_cost > 0 %}
-                                                            {% widthratio billable_equipment equipment_cost 100 as equipment_margin %}
-                                                            <div class="metric-value {% if equipment_margin >= 150 %}text-success{% elif equipment_margin >= 120 %}text-warning{% else %}text-danger{% endif %}">
-                                                                {{ equipment_margin|add:"-100"|floatformat:0 }}%
-                                                            </div>
-                                                        {% else %}
-                                                            <div class="metric-value text-muted">—</div>
-                                                        {% endif %}
-                                                        <div class="metric-label">Margin</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="progress-comparison mt-2">
-                                            <div class="progress" style="height: 8px;">
-                                                {% if billable_equipment > 0 %}
-                                                    <div class="progress-bar bg-danger" style="width: {{ equip_cost_percent|floatformat:0 }}%" title="Cost: {{ equip_cost_percent|floatformat:0 }}%"></div>
-                                                    <div class="progress-bar bg-success" style="width: {{ equip_profit_percent|floatformat:0 }}%" title="Profit: {{ equip_profit_percent|floatformat:0 }}%"></div>
-                                                {% endif %}
-                                            </div>
-                                                <div class="progress-labels d-flex justify-content-between mt-1">
-                                                    <small class="text-muted">Cost vs Revenue comparison</small>
-                                                    <small class="{% if equipment_cost < billable_equipment %}text-success{% else %}text-danger{% endif %}">
-                                                        {% if equipment_cost < billable_equipment %}Profitable{% else %}Loss{% endif %}
-                                                    </small>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Materials Analysis -->
-                            <div class="category-analysis-row mb-4">
-                                <div class="row">
-                                    <div class="col-md-4">
-                                        <div class="category-header">
-                                            <div class="category-icon bg-secondary">
-                                                <i class="fas fa-boxes"></i>
-                                            </div>
-                                            <div class="category-info">
-                                                <h6 class="category-name">Materials</h6>
-                                                <p class="category-desc">Material costs & markup</p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="col-md-8">
-                                        <div class="category-metrics">
-                                            <div class="row">
-                                                <div class="col-sm-3">
-                                                    <div class="metric-box">
-                                                        <div class="metric-value text-danger">${{ material_cost|floatformat:0|intcomma }}</div>
-                                                        <div class="metric-label">Cost</div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    <div class="metric-box">
-                                                        <div class="metric-value text-success">${{ billable_material|floatformat:0|intcomma }}</div>
-                                                        <div class="metric-label">Billed</div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    <div class="metric-box">
-                                                        <div class="metric-value text-primary">${{ material_profit|floatformat:0|intcomma }}</div>
-                                                        <div class="metric-label">Profit</div>
-                                                    </div>
-                                                </div>
-                                                <div class="col-sm-3">
-                                                    <div class="metric-box">
-                                                        {% if material_cost > 0 %}
-                                                            {% widthratio billable_material material_cost 100 as material_margin %}
-                                                            <div class="metric-value {% if material_margin >= 125 %}text-success{% elif material_margin >= 110 %}text-warning{% else %}text-danger{% endif %}">
-                                                                {{ material_margin|add:"-100"|floatformat:0 }}%
-                                                            </div>
-                                                        {% else %}
-                                                            <div class="metric-value text-muted">—</div>
-                                                        {% endif %}
-                                                        <div class="metric-label">Markup</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="progress-comparison mt-2">
-                                            <div class="progress" style="height: 8px;">
-                                                {% if billable_material > 0 %}
-                                                    <div class="progress-bar bg-danger" style="width: {{ mat_cost_percent|floatformat:0 }}%" title="Cost: {{ mat_cost_percent|floatformat:0 }}%"></div>
-                                                    <div class="progress-bar bg-success" style="width: {{ mat_profit_percent|floatformat:0 }}%" title="Profit: {{ mat_profit_percent|floatformat:0 }}%"></div>
-                                                {% endif %}
-                                            </div>
-                                                <div class="progress-labels d-flex justify-content-between mt-1">
-                                                    <small class="text-muted">Cost vs Revenue comparison</small>
-                                                    <small class="{% if material_cost < billable_material %}text-success{% else %}text-danger{% endif %}">
-                                                        {% if material_cost < billable_material %}Profitable{% else %}Loss{% endif %}
-                                                    </small>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Business Insights & Recommendations -->
-                <div class="row mb-4">
-                    <div class="col-md-6">
-                        <div class="insights-card h-100">
-                            <div class="insights-header">
-                                <h6 class="insights-title">
-                                    <i class="fas fa-lightbulb me-2 text-warning"></i>
-                                    Business Insights
-                                </h6>
-                            </div>
-                            <div class="insights-content">
-                                <div class="insight-item">
-                                    <div class="insight-icon">
-                                        <i class="fas {% if margin >= 20 %}fa-trophy text-success{% elif margin >= 10 %}fa-thumbs-up text-warning{% else %}fa-exclamation-triangle text-danger{% endif %}"></i>
-                                    </div>
-                                    <div class="insight-text">
-                                        <strong>Profitability:</strong>
-                                        {% if margin >= 20 %}
-                                            Excellent profit margin! Your pricing strategy is working well.
-                                        {% elif margin >= 10 %}
-                                            Good profit margin. Consider optimizing costs for better returns.
-                                        {% else %}
-                                            Low profit margin. Review pricing and cost management strategies.
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                
-                                <div class="insight-item">
-                                    <div class="insight-icon">
-                                        {% if labor_cost > equipment_cost and labor_cost > material_cost %}
-                                            <i class="fas fa-users text-primary"></i>
-                                        {% elif equipment_cost > labor_cost and equipment_cost > material_cost %}
-                                            <i class="fas fa-cogs text-warning"></i>
-                                        {% else %}
-                                            <i class="fas fa-box text-secondary"></i>
-                                        {% endif %}
-                                    </div>
-                                    <div class="insight-text">
-                                        <strong>Cost Driver:</strong>
-                                        {% if labor_cost > equipment_cost and labor_cost > material_cost %}
-                                            Labor is your primary cost center ({{ labor_percent|floatformat:0 }}% of costs).
-                                        {% elif equipment_cost > labor_cost and equipment_cost > material_cost %}
-                                            Equipment costs dominate this project ({{ equipment_percent|floatformat:0 }}% of costs).
-                                        {% else %}
-                                            Materials represent the largest cost category ({{ material_percent|floatformat:0 }}% of costs).
-                                        {% endif %}
-                                    </div>
-                                </div>
-
-                                <div class="insight-item">
-                                    <div class="insight-icon">
-                                        <i class="fas fa-chart-line text-info"></i>
-                                    </div>
-                                    <div class="insight-text">
-                                        <strong>Efficiency:</strong>
-                                        {% if total_hours > 0 %}
-                                            Your average billing rate is ${{ avg_hourly_rate|floatformat:0 }}/hour across all categories.
-                                        {% else %}
-                                            No hours logged yet for efficiency calculation.
-                                        {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- remove growth opportunities card from project analytics view
- add equipment and materials performance analysis rows alongside labor
- restore business insights section after performance trends

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7905052348330ad3a8c2ee9ec95dd