### PR TITLE
Remove breadcrumb from project detail and center analytics summary

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -592,15 +592,6 @@
     <div class="container">
         <div class="row align-items-center">
             <div class="col-lg-8">
-                <!-- Breadcrumb -->
-                <nav aria-label="breadcrumb" class="mb-3">
-                    <ol class="breadcrumb breadcrumb-custom">
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:contractor_summary' %}"><i class="fas fa-home me-1"></i>Dashboard</a></li>
-                        <li class="breadcrumb-item"><a href="{% url 'dashboard:project_list' %}">Projects</a></li>
-                        <li class="breadcrumb-item active">{{ project.name }}</li>
-                    </ol>
-                </nav>
-
                 <h1 class="display-5 mb-2">{{ project.name }}</h1>
                 <p class="lead mb-3">
                     {% if project.end_date %}
@@ -1033,9 +1024,9 @@
                             <h5 class="mb-1">Project Analytics</h5>
                             <p class="text-muted mb-0">Comprehensive business insights and profitability analysis</p>
                         </div>
-                        <div class="col-md-4 text-md-end">
-                            <div class="analytics-summary">
-                                <div class="d-flex justify-content-end align-items-center gap-3">
+                        <div class="col-md-4">
+                            <div class="analytics-summary text-center">
+                                <div class="d-flex justify-content-center align-items-center gap-3">
                                     <div class="text-center">
                                         <div class="h4 mb-0 text-success">${{ profit|floatformat:0|intcomma }}</div>
                                         <small class="text-muted">Total Profit</small>

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -529,6 +529,28 @@ class ReportsPageTests(TestCase):
         self.assertNotContains(response, '<nav aria-label="breadcrumb"')
 
 
+class ProjectDetailPageTests(TestCase):
+    def setUp(self):
+        self.contractor = Contractor.objects.create(
+            name="Test Contractor", email="user@example.com"
+        )
+        ContractorUser.objects.create_user(
+            email="user@example.com", password="secret", contractor=self.contractor
+        )
+        self.project = self.contractor.projects.create(
+            name="Proj", start_date="2024-01-01"
+        )
+
+    def test_project_detail_has_no_breadcrumb(self):
+        self.client.post(
+            reverse("login"), {"username": "user@example.com", "password": "secret"}
+        )
+        response = self.client.get(
+            reverse("dashboard:project_detail", args=[self.project.pk])
+        )
+        self.assertNotContains(response, '<nav aria-label="breadcrumb"')
+
+
 class ProjectDetailRobustnessTests(TestCase):
     def test_project_detail_handles_bad_numeric_data(self):
         contractor = Contractor.objects.create(


### PR DESCRIPTION
## Summary
- remove breadcrumb navigation from project detail header
- center the analytics summary profit and margin values
- add regression test ensuring project detail has no breadcrumb

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b793bfbd08833082f3130634b9feac