### PR TITLE
Improve tab hover contrast

### DIFF
--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1230,6 +1230,10 @@ textarea:focus {
     font-weight: 600;
 }
 
+.nav-tabs-custom .nav-link:hover {
+    color: var(--primary-color) !important;
+}
+
 .nav-tabs-custom .nav-link.active {
     background: var(--primary-gradient);
     color: white;


### PR DESCRIPTION
## Summary
- ensure job detail tab labels use primary color text on hover instead of white for better contrast

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b79ddc7ad48330b1b2f24a7f278bab