### PR TITLE
Ensure tab hover text uses green across site

### DIFF
--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1261,6 +1261,10 @@ textarea:focus {
     padding: 15px 25px;
 }
 
+.nav-tabs .nav-link:hover {
+    color: var(--primary-color) !important;
+}
+
 .nav-tabs .nav-link.active {
     background: var(--primary-gradient);
     color: #fff !important;


### PR DESCRIPTION
## Summary
- make tab hover text use primary green instead of white

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b7a37c0fc8833085f741f89fa5ae1b