### PR TITLE
Add favicon and touch icons to templates

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -9,7 +9,11 @@
     <title>{% block title %}Dashboard{% endblock %} | Squire Enterprises</title>
     
     <!-- Favicons -->
-    <link rel="icon" type="image/png" href="{% static 'img/favicon.png' %}">
+    <link rel="icon" href="{% static 'img/favicon.ico' %}" type="image/x-icon">
+    <link rel="icon" href="{% static 'img/favicon-96x96.png' %}" sizes="96x96" type="image/png">
+    <link rel="apple-touch-icon" href="{% static 'img/apple-touch-icon.png' %}">
+    <link rel="icon" href="{% static 'img/web-app-manifest-192x192.png' %}" sizes="192x192" type="image/png">
+    <link rel="icon" href="{% static 'img/web-app-manifest-512x512.png' %}" sizes="512x512" type="image/png">
     
     <!-- External CSS Libraries -->
     {% if not report %}

--- a/jobtracker/templates/registration/login.html
+++ b/jobtracker/templates/registration/login.html
@@ -11,7 +11,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <link href="{% static 'css/squire.css' %}" rel="stylesheet">
     <title>Sign In | Squire Enterprises</title>
-    <link rel="icon" type="image/png" href="{% static 'img/favicon.png' %}">
+    <link rel="icon" href="{% static 'img/favicon.ico' %}" type="image/x-icon">
+    <link rel="icon" href="{% static 'img/favicon-96x96.png' %}" sizes="96x96" type="image/png">
+    <link rel="apple-touch-icon" href="{% static 'img/apple-touch-icon.png' %}">
+    <link rel="icon" href="{% static 'img/web-app-manifest-192x192.png' %}" sizes="192x192" type="image/png">
+    <link rel="icon" href="{% static 'img/web-app-manifest-512x512.png' %}" sizes="512x512" type="image/png">
     
     <style>
        body {


### PR DESCRIPTION
## Summary
- reference favicon and touch icons in dashboard and login templates
- support multiple icon sizes for better platform integration

## Testing
- `python manage.py collectstatic --noinput`

------
https://chatgpt.com/codex/tasks/task_e_68b7a3d3b61483308b453d6ea048ae21