### PR TITLE
Initialize labor entry row on job entry form

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -330,6 +330,9 @@ document.addEventListener('DOMContentLoaded', function() {
     // Initialize progress tracker
     setActiveStep(1);
 
+    // Add initial equipment/labor entry
+    addLaborEntry();
+
     document.getElementById('labor-tab').addEventListener('shown.bs.tab', () => setActiveStep(2));
     document.getElementById('materials-tab').addEventListener('shown.bs.tab', () => setActiveStep(3));
     document.getElementById('date').addEventListener('focus', () => setActiveStep(1));


### PR DESCRIPTION
## Summary
- Automatically create an initial Equipment/Labor entry when opening the job entry form so the user can start filling immediately.

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b7a52c8e3483309aabcb473e558aa7