### PR TITLE
Hide Load Recent Entry button

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -10,8 +10,8 @@
         </h1>
         <p class="text-muted mb-0">Add job entries for <strong>{{ project.name }}</strong></p>
     </div>
-    <div>
-        <button class="btn btn-outline-secondary" type="button" onclick="loadRecentEntry()">
+    <div class="d-none">
+        <button class="btn btn-outline-secondary" type="button">
             <i class="fas fa-history me-2"></i>Load Recent Entry
         </button>
     </div>
@@ -514,10 +514,6 @@ function clearAll() {
         clearAllMaterials();
         updateTotals();
     }
-}
-
-function loadRecentEntry() {
-    alert('Loading most recent entry...');
 }
 
 // Form submission


### PR DESCRIPTION
## Summary
- hide unused Load Recent Entry button on job entry form
- remove placeholder `loadRecentEntry` function

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7a498bbcc8330a4196720aa35a35a