### PR TITLE
Hide quick actions on job entry page

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -228,7 +228,7 @@
                 </div>
             </div>
 
-            <!-- Quick Actions -->
+            <!-- Quick Actions temporarily disabled
             <div class="card">
                 <div class="card-header">
                     <h6 class="mb-0"><i class="fas fa-history me-2"></i>Quick Actions</h6>
@@ -244,6 +244,7 @@
                     </div>
                 </div>
             </div>
+            -->
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Temporarily hide the Quick Actions card on the job entry page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7a5e3e2ac8330b21a3439df9381dc