### PR TITLE
style: improve contractor name header styling

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -182,7 +182,7 @@
             
             <!-- Contractor Name or Site Name -->
             {% if contractor %}
-                <span class="navbar-brand mb-0 fw-bold">{{ contractor.name|default:contractor.email }}</span>
+                <span class="navbar-brand contractor-name mb-0">{{ contractor.name|default:contractor.email }}</span>
             {% else %}
                 <span class="navbar-brand mb-0 fw-bold">Squire Enterprises</span>
             {% endif %}

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -392,6 +392,16 @@ textarea:focus {
     background-clip: text;
 }
 
+.contractor-name {
+    font-weight: 700;
+    background: var(--primary-gradient);
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    display: inline-block;
+}
+
 .nav-link {
     color: var(--text-primary) !important;
     font-weight: 500;


### PR DESCRIPTION
## Summary
- style contractor name in dashboard header to use brand gradient
- add reusable `.contractor-name` class for cross-browser text gradient

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b7a7336ef08330b9097cd4baa319f3