### PR TITLE
Update favicon references

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -9,11 +9,13 @@
     <title>{% block title %}Dashboard{% endblock %} | Squire Enterprises</title>
     
     <!-- Favicons -->
-    <link rel="icon" href="{% static 'img/favicon.ico' %}" type="image/x-icon">
-    <link rel="icon" href="{% static 'img/favicon-96x96.png' %}" sizes="96x96" type="image/png">
+    <link rel="icon" href="{% static 'img/favicon.ico' %}" sizes="any">
+    <link rel="icon" href="{% static 'img/favicon-16x16.png' %}" sizes="16x16" type="image/png">
+    <link rel="icon" href="{% static 'img/favicon-32x32.png' %}" sizes="32x32" type="image/png">
     <link rel="apple-touch-icon" href="{% static 'img/apple-touch-icon.png' %}">
-    <link rel="icon" href="{% static 'img/web-app-manifest-192x192.png' %}" sizes="192x192" type="image/png">
-    <link rel="icon" href="{% static 'img/web-app-manifest-512x512.png' %}" sizes="512x512" type="image/png">
+    <link rel="icon" href="{% static 'img/android-chrome-192x192.png' %}" sizes="192x192" type="image/png">
+    <link rel="icon" href="{% static 'img/android-chrome-512x512.png' %}" sizes="512x512" type="image/png">
+    <link rel="manifest" href="{% static 'img/site.webmanifest' %}">
     
     <!-- External CSS Libraries -->
     {% if not report %}

--- a/jobtracker/templates/registration/login.html
+++ b/jobtracker/templates/registration/login.html
@@ -11,11 +11,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <link href="{% static 'css/squire.css' %}" rel="stylesheet">
     <title>Sign In | Squire Enterprises</title>
-    <link rel="icon" href="{% static 'img/favicon.ico' %}" type="image/x-icon">
-    <link rel="icon" href="{% static 'img/favicon-96x96.png' %}" sizes="96x96" type="image/png">
+    <link rel="icon" href="{% static 'img/favicon.ico' %}" sizes="any">
+    <link rel="icon" href="{% static 'img/favicon-16x16.png' %}" sizes="16x16" type="image/png">
+    <link rel="icon" href="{% static 'img/favicon-32x32.png' %}" sizes="32x32" type="image/png">
     <link rel="apple-touch-icon" href="{% static 'img/apple-touch-icon.png' %}">
-    <link rel="icon" href="{% static 'img/web-app-manifest-192x192.png' %}" sizes="192x192" type="image/png">
-    <link rel="icon" href="{% static 'img/web-app-manifest-512x512.png' %}" sizes="512x512" type="image/png">
+    <link rel="icon" href="{% static 'img/android-chrome-192x192.png' %}" sizes="192x192" type="image/png">
+    <link rel="icon" href="{% static 'img/android-chrome-512x512.png' %}" sizes="512x512" type="image/png">
+    <link rel="manifest" href="{% static 'img/site.webmanifest' %}">
     
     <style>
        body {


### PR DESCRIPTION
## Summary
- switch login and dashboard templates to new favicon set

## Testing
- `cd jobtracker && python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b7ad5c7f148330b4c7030f5a3fb1f3