### PR TITLE
Align project card widths on selection screen

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/select_project.html
+++ b/jobtracker/dashboard/templates/dashboard/select_project.html
@@ -12,8 +12,8 @@
 {% if projects %}
 <div class="row">
     {% for project in projects %}
-    <div class="col-lg-4 col-md-6 mb-4 d-flex">
-        <div class="card h-100 project-card selectable-card flex-fill"
+    <div class="col-12 col-md-6 col-lg-4 mb-4 d-flex">
+        <div class="card h-100 project-card selectable-card w-100"
              role="button"
              onclick="location.href='{% url action_url_name project.pk %}'">
                 <div class="card-body">
@@ -91,6 +91,8 @@
     box-shadow: var(--shadow-md);
     display: flex;
     flex-direction: column;
+    min-height: 250px;
+    width: 100%;
 }
 
 .project-card .card-body {


### PR DESCRIPTION
## Summary
- Ensure project cards expand to fill their grid columns so they render with consistent width across breakpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7af06006c8330a44c4f7804b0d93a