### PR TITLE
Improve mobile timeline and remove unused project actions

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -651,16 +651,6 @@
                     <a href="{% url 'dashboard:contractor_job_report' project.pk %}" class="btn btn-info text-white">
                         <i class="fas fa-hard-hat me-2"></i>Job Report
                     </a>
-                    <div class="dropdown">
-                        <button class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown">
-                            <i class="fas fa-ellipsis-h me-2"></i>More Actions
-                        </button>
-                        <ul class="dropdown-menu">
-                            <li><a class="dropdown-item" href="#"><i class="fas fa-edit me-2"></i>Edit Project</a></li>
-                            <li><a class="dropdown-item" href="#"><i class="fas fa-copy me-2"></i>Duplicate</a></li>
-                            <li><a class="dropdown-item" href="#"><i class="fas fa-archive me-2"></i>Archive</a></li>
-                        </ul>
-                    </div>
                 </div>
             </div>
             <div class="col-md-4">

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -996,6 +996,26 @@ textarea:focus {
     background: var(--primary-color);
 }
 
+@media (max-width: 576px) {
+    .timeline-item {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .timeline-date {
+        width: 100%;
+        text-align: left;
+        margin-bottom: 10px;
+    }
+    .timeline-content {
+        border-left: none;
+        margin-left: 0;
+        padding-left: 0;
+    }
+    .timeline-content::before {
+        display: none;
+    }
+}
+
 /* Entry and Form Styles */
 .entry-row {
     background: white;


### PR DESCRIPTION
## Summary
- Make project analytics timeline responsive on mobile
- Remove unused "More Actions" dropdown from project detail page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7b36c06148330ac1c995229500523