### PR TITLE
Improve mobile layout for job entries

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -769,25 +769,23 @@
         <!-- Job Entries Tab -->
         <div class="tab-pane fade show active" id="entries-tab">
             <div class="tab-content-card">
-                <div class="d-flex justify-content-between align-items-center mb-4">
-                    <h5 class="mb-0">Job Entries</h5>
-                    <div class="d-flex gap-2">
-                        <div class="btn-group btn-group-sm" role="group">
-                            <input type="radio" class="btn-check" name="entry-filter" id="filter-all" checked>
-                            <label class="btn btn-outline-secondary" for="filter-all">All</label>
-                            
-                            <input type="radio" class="btn-check" name="entry-filter" id="filter-labor">
-                            <label class="btn btn-outline-secondary" for="filter-labor">Labor</label>
-                            
-                            <input type="radio" class="btn-check" name="entry-filter" id="filter-equipment">
-                            <label class="btn btn-outline-secondary" for="filter-equipment">Equipment</label>
-                            
-                            <input type="radio" class="btn-check" name="entry-filter" id="filter-materials">
-                            <label class="btn btn-outline-secondary" for="filter-materials">Materials</label>
-                        </div>
+                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-4">
+                    <h5 class="mb-0 me-3">Job Entries</h5>
+                    <div class="btn-group btn-group-sm flex-wrap" role="group">
+                        <input type="radio" class="btn-check" name="entry-filter" id="filter-all" checked>
+                        <label class="btn btn-outline-secondary" for="filter-all">All</label>
+
+                        <input type="radio" class="btn-check" name="entry-filter" id="filter-labor">
+                        <label class="btn btn-outline-secondary" for="filter-labor">Labor</label>
+
+                        <input type="radio" class="btn-check" name="entry-filter" id="filter-equipment">
+                        <label class="btn btn-outline-secondary" for="filter-equipment">Equipment</label>
+
+                        <input type="radio" class="btn-check" name="entry-filter" id="filter-materials">
+                        <label class="btn btn-outline-secondary" for="filter-materials">Materials</label>
                     </div>
                 </div>
-
+                
                 <!-- Entry Rows -->
                 {% for entry in job_entries %}
                 <div class="entry-row{% if forloop.counter > 10 %} d-none{% endif %}" data-entry-type="{% if entry.employee %}labor{% elif entry.asset %}equipment{% elif entry.material_description %}materials{% else %}other{% endif %}">

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1058,6 +1058,22 @@ textarea:focus {
     color: #f57c00;
 }
 
+@media (max-width: 576px) {
+    .entry-row .d-flex {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .entry-row .entry-type-icon {
+        margin-right: 0;
+        margin-bottom: 10px;
+    }
+    .entry-row .text-end {
+        width: 100%;
+        text-align: left !important;
+        margin-top: 10px;
+    }
+}
+
 /* Enhanced Job Entry Form Styles */
 .quick-add-card {
     cursor: pointer;


### PR DESCRIPTION
## Summary
- Ensure Job Entries heading and filters wrap cleanly on small screens
- Stack entry card content vertically on mobile to prevent overflow

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b844ffaac48330a3008aec04c7ee3f