### PR TITLE
Keep job entry action buttons horizontal on mobile

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -818,7 +818,7 @@
                                 </div>
                             </div>
                             <div class="d-flex justify-content-between align-items-center">
-                                <div class="d-flex gap-2">
+                                <div class="d-flex flex-wrap gap-2 job-entry-tags">
                                     {% if entry.asset %}
                                         <span class="badge bg-primary">{{ entry.asset.name }}</span>
                                     {% endif %}
@@ -832,7 +832,7 @@
                                         <span class="badge bg-warning text-dark">${{ entry.material_cost|floatformat:2 }} cost</span>
                                     {% endif %}
                                 </div>
-                                <div class="btn-group btn-group-sm">
+                                <div class="btn-group btn-group-sm job-entry-actions">
                                     <a href="{% url 'dashboard:edit_job_entry' entry.pk %}" class="btn btn-outline-secondary" title="Edit Entry">
                                         <i class="fas fa-edit"></i>
                                     </a>

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1662,10 +1662,29 @@ textarea.form-control {
     .btn-group {
         flex-direction: column;
     }
-    
+
     .btn-group .btn {
         margin-bottom: 5px;
         border-radius: var(--radius-md) !important;
+    }
+
+    /* Override for job entry action buttons to stay horizontal on small screens */
+    .job-entry-actions {
+        flex-direction: row;
+    }
+
+    .job-entry-actions .btn {
+        margin-bottom: 0;
+        margin-right: 5px;
+    }
+
+    .job-entry-actions .btn:last-child {
+        margin-right: 0;
+    }
+
+    .entry-row .job-entry-tags {
+        flex-direction: row;
+        flex-wrap: wrap;
     }
 }
 


### PR DESCRIPTION
## Summary
- Ensure job entry action buttons remain horizontal on small screens
- Ensure job entry equipment/employee/material tags wrap horizontally on mobile

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b847eaa9048330b0714f49bad902bd