### PR TITLE
Improve mobile job entry layout

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -832,14 +832,14 @@
                                         <span class="badge bg-warning text-dark">${{ entry.material_cost|floatformat:2 }} cost</span>
                                     {% endif %}
                                 </div>
-                                <div class="btn-group btn-group-sm job-entry-actions">
-                                    <a href="{% url 'dashboard:edit_job_entry' entry.pk %}" class="btn btn-outline-secondary" title="Edit Entry">
+                                <div class="d-flex flex-row flex-nowrap gap-2 job-entry-actions">
+                                    <a href="{% url 'dashboard:edit_job_entry' entry.pk %}" class="btn btn-sm btn-outline-secondary" title="Edit Entry">
                                         <i class="fas fa-edit"></i>
                                     </a>
-                                    <button class="btn btn-outline-secondary" title="Duplicate Entry" onclick="duplicateEntry({{ entry.pk }})">
+                                    <button class="btn btn-sm btn-outline-secondary" title="Duplicate Entry" onclick="duplicateEntry({{ entry.pk }})">
                                         <i class="fas fa-copy"></i>
                                     </button>
-                                    <button class="btn btn-outline-danger" title="Delete Entry" onclick="deleteEntry({{ entry.pk }})">
+                                    <button class="btn btn-sm btn-outline-danger" title="Delete Entry" onclick="deleteEntry({{ entry.pk }})">
                                         <i class="fas fa-trash"></i>
                                     </button>
                                 </div>

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -768,6 +768,16 @@ textarea:focus {
     color: var(--text-primary) !important;
 }
 
+/* Job entry tag spacing */
+.job-entry-tags .badge {
+    margin-right: 0.25rem;
+    margin-bottom: 0.25rem;
+}
+
+.job-entry-tags .badge:last-child {
+    margin-right: 0;
+}
+
 /* Floating Action Buttons */
 
 .floating-add {
@@ -830,6 +840,15 @@ textarea:focus {
 
 .floating-btn.warning {
     background: var(--warning-gradient);
+}
+
+/* Job entry action buttons spacing */
+.job-entry-actions .btn {
+    margin-right: 5px;
+}
+
+.job-entry-actions .btn:last-child {
+    margin-right: 0;
 }
 
 /* Stats and Metrics */
@@ -1658,7 +1677,7 @@ textarea.form-control {
     .card-body {
         padding: 15px;
     }
-    
+
     .btn-group {
         flex-direction: column;
     }
@@ -1668,18 +1687,8 @@ textarea.form-control {
         border-radius: var(--radius-md) !important;
     }
 
-    /* Override for job entry action buttons to stay horizontal on small screens */
-    .job-entry-actions {
-        flex-direction: row;
-    }
-
-    .job-entry-actions .btn {
-        margin-bottom: 0;
-        margin-right: 5px;
-    }
-
-    .job-entry-actions .btn:last-child {
-        margin-right: 0;
+    .floating-actions {
+        display: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- Space job entry tags to prevent overlapping on small screens
- Display job entry action buttons in a horizontal row with compact sizing
- Hide floating action buttons on mobile to declutter project pages

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b84dedfd188330b92576a8b053a6b5