### PR TITLE
Improve mobile layout for payments tab

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -923,9 +923,10 @@
                         </tbody>
                         <tfoot>
                             <tr class="table-light">
-                                <td><strong>Total Payments</strong></td>
-                                <td><strong class="fs-5 text-success">${{ total_payments|floatformat:2|intcomma }}</strong></td>
-                                <td colspan="2"></td>
+                                <td colspan="4" class="text-end">
+                                    <strong>Total Payments:</strong>
+                                    <span class="fs-5 text-success">${{ total_payments|floatformat:2|intcomma }}</span>
+                                </td>
                             </tr>
                         </tfoot>
                     </table>

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1311,6 +1311,24 @@ textarea:focus {
     padding: 25px;
 }
 
+@media (max-width: 576px) {
+    .tab-content-card {
+        background: transparent;
+        box-shadow: none;
+        padding: 10px 0;
+    }
+
+    .materials-table {
+        background: transparent;
+        border-radius: 0;
+    }
+
+    .materials-table th,
+    .materials-table td {
+        padding: 8px 6px;
+    }
+}
+
 .entry-tabs {
     border: none;
     margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- Simplify total payments row to use full width and align amount to the right
- Reduce nested card styling on mobile for payment tables

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b87026d7fc83309e884f88d3783d9a