### PR TITLE
Fix project list footer layout on mobile

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_list.html
+++ b/jobtracker/dashboard/templates/dashboard/project_list.html
@@ -91,10 +91,10 @@
             
             <div class="card-footer bg-transparent">
                 <div class="d-flex justify-content-between align-items-center">
-                    <small class="text-muted">
+                    <small class="text-muted text-nowrap">
                         <i class="fas fa-calendar me-1"></i>Started {{ project.start_date|date:"M d, Y" }}
                     </small>
-                    <div class="btn-group btn-group-sm">
+                    <div class="btn-group btn-group-sm flex-nowrap">
                         <a href="{% url 'dashboard:add_job_entry' project.pk %}" class="btn btn-outline-success btn-sm" title="Add Job Entry">
                             <i class="fas fa-plus"></i>
                         </a>


### PR DESCRIPTION
## Summary
- keep project list start date and action buttons on one line on mobile

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b8df5a77908330aab336630bf2f103