### PR TITLE
Fix mobile spacing for project detail search field

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -653,7 +653,7 @@
                     </a>
                 </div>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-4 mt-3 mt-md-0">
                 <div class="input-group">
                     <span class="input-group-text"><i class="fas fa-search"></i></span>
                     <input type="text" class="form-control" placeholder="Search entries..." id="search-entries">


### PR DESCRIPTION
## Summary
- add mobile top margin to search field so Job Report button doesn't crowd it

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b8df9b50908330a931c689ecfe7475