### PR TITLE
Improve mobile layout for job detail tabs

### DIFF
--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1304,6 +1304,19 @@ textarea:focus {
     color: white;
 }
 
+@media (max-width: 576px) {
+    .nav-tabs-custom {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .nav-tabs-custom .nav-link {
+        white-space: nowrap;
+        flex: 0 0 auto;
+    }
+}
+
 .tab-content-card {
     background: var(--card-background);
     border-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary
- Make job detail tabs horizontally scrollable on small screens to prevent awkward wrapping

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b8e033869c8330a5d4d7c548636ffc