### PR TITLE
Fix estimate migration to avoid pending trigger events

### DIFF
--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -59,7 +59,7 @@ def contractor_summary(request):
         return redirect("login")
 
     projects = contractor.projects.filter(
-        end_date__isnull=True, is_estimate=False
+        end_date__isnull=True
     ).prefetch_related("job_entries", "payments")
     for p in projects:
         p.total_billable = sum((je.billable_amount or 0) for je in p.job_entries.all())
@@ -133,7 +133,7 @@ def project_list(request):
     # Search functionality
     search_query = request.GET.get("search", "")
     projects = contractor.projects.filter(
-        end_date__isnull=True, is_estimate=False
+        end_date__isnull=True
     ).prefetch_related("job_entries", "payments")
 
     if search_query:
@@ -238,7 +238,7 @@ def reports(request):
         return redirect("login")
 
     projects = contractor.projects.filter(
-        end_date__isnull=True, is_estimate=False
+        end_date__isnull=True
     ).prefetch_related("job_entries", "payments")
 
     for p in projects:
@@ -537,7 +537,7 @@ def select_job_entry_project(request):
         return redirect("login")
 
     projects = contractor.projects.filter(
-        end_date__isnull=True, is_estimate=False
+        end_date__isnull=True
     ).prefetch_related("job_entries", "payments")
 
     for p in projects:
@@ -567,7 +567,7 @@ def select_payment_project(request):
         return redirect("login")
 
     projects = contractor.projects.filter(
-        end_date__isnull=True, is_estimate=False
+        end_date__isnull=True
     ).prefetch_related("job_entries", "payments")
 
     for p in projects:

--- a/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
+++ b/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
@@ -17,7 +17,8 @@ def forward_migrate_estimates(apps, schema_editor):
             created_date=project.start_date or django.utils.timezone.now().date(),
         )
         EstimateEntry.objects.filter(project=project).update(estimate=estimate)
-        project.delete()
+        project.end_date = project.end_date or django.utils.timezone.now().date()
+        project.save(update_fields=["end_date"])
 
 
 class Migration(migrations.Migration):

--- a/jobtracker/tracker/models.py
+++ b/jobtracker/tracker/models.py
@@ -140,7 +140,6 @@ class Project(models.Model):
     name = models.CharField(max_length=255)
     start_date = models.DateField()
     end_date = models.DateField(blank=True, null=True)
-    is_estimate = models.BooleanField(default=False)
 
     def __str__(self) -> str:
         return self.name


### PR DESCRIPTION
## Summary
- Avoid deleting projects during migration and close them instead
- Remove deprecated `is_estimate` flag from `Project` model
- Drop obsolete estimate flag filters in dashboard views

## Testing
- `pytest -q`
- `python jobtracker/manage.py test`
- `python jobtracker/manage.py migrate --no-input`


------
https://chatgpt.com/codex/tasks/task_e_68b9df3eb1388330ae4b0f7b0949fba3