### PR TITLE
Mark migration non-atomic to avoid pending triggers

### DIFF
--- a/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
+++ b/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
@@ -21,6 +21,7 @@ def forward_migrate_estimates(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
+    atomic = False
 
     dependencies = [
         ("tracker", "0007_project_is_estimate"),


### PR DESCRIPTION
## Summary
- allow tracker migration to run outside a transaction to avoid pending trigger events on Render

## Testing
- `python jobtracker/manage.py test`
- `python jobtracker/manage.py migrate`


------
https://chatgpt.com/codex/tasks/task_e_68b9e3eb69808330a867fd7d59ae46b1