### PR TITLE
Handle existing Estimate table during migration

### DIFF
--- a/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
+++ b/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
@@ -18,10 +18,13 @@ def forward_migrate_estimates(apps, schema_editor):
     projects = Project.objects.filter(estimate_entries__isnull=False).distinct()
 
     for project in projects:
-        estimate = Estimate.objects.create(
+        estimate, _ = Estimate.objects.get_or_create(
             contractor=project.contractor,
             name=project.name,
-            created_date=project.start_date or django.utils.timezone.now().date(),
+            defaults={
+                "created_date": project.start_date
+                or django.utils.timezone.now().date(),
+            },
         )
         EstimateEntry.objects.filter(project=project).update(estimate=estimate)
         project.end_date = project.end_date or django.utils.timezone.now().date()
@@ -62,6 +65,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
+            if_not_exists=True,
         ),
         migrations.AddField(
             model_name="estimateentry",


### PR DESCRIPTION
## Summary
- make Estimate creation idempotent and avoid duplicates
- allow migration to skip creating `tracker_estimate` table if it already exists

## Testing
- `python jobtracker/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b9fb154ad88330a5f6f2ab737dcab9