### PR TITLE
Handle existing Estimate table during migration

### DIFF
--- a/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
+++ b/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
@@ -18,14 +18,25 @@ def forward_migrate_estimates(apps, schema_editor):
     projects = Project.objects.filter(estimate_entries__isnull=False).distinct()
 
     for project in projects:
-        estimate = Estimate.objects.create(
+        estimate, _ = Estimate.objects.get_or_create(
             contractor=project.contractor,
             name=project.name,
-            created_date=project.start_date or django.utils.timezone.now().date(),
+            defaults={
+                "created_date": project.start_date
+                or django.utils.timezone.now().date(),
+            },
         )
         EstimateEntry.objects.filter(project=project).update(estimate=estimate)
         project.end_date = project.end_date or django.utils.timezone.now().date()
         project.save(update_fields=["end_date"])
+
+
+def create_estimate_table(apps, schema_editor):
+    if "tracker_estimate" in schema_editor.connection.introspection.table_names():
+        return
+    from tracker.models import Estimate
+
+    schema_editor.create_model(Estimate)
 
 
 class Migration(migrations.Migration):
@@ -36,31 +47,38 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.CreateModel(
-            name="Estimate",
-            fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                ("name", models.CharField(max_length=255)),
-                (
-                    "created_date",
-                    models.DateField(default=django.utils.timezone.now),
-                ),
-                (
-                    "contractor",
-                    models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
-                        related_name="estimates",
-                        to="tracker.contractor",
-                    ),
-                ),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="Estimate",
+                    fields=[
+                        (
+                            "id",
+                            models.BigAutoField(
+                                auto_created=True,
+                                primary_key=True,
+                                serialize=False,
+                                verbose_name="ID",
+                            ),
+                        ),
+                        ("name", models.CharField(max_length=255)),
+                        (
+                            "created_date",
+                            models.DateField(default=django.utils.timezone.now),
+                        ),
+                        (
+                            "contractor",
+                            models.ForeignKey(
+                                on_delete=django.db.models.deletion.CASCADE,
+                                related_name="estimates",
+                                to="tracker.contractor",
+                            ),
+                        ),
+                    ],
+                )
+            ],
+            database_operations=[
+                migrations.RunPython(create_estimate_table, migrations.RunPython.noop)
             ],
         ),
         migrations.AddField(


### PR DESCRIPTION
## Summary
- create Estimate table conditionally to avoid duplicate-table errors
- swap CreateModel for SeparateDatabaseAndState to reuse existing tables

## Testing
- `python jobtracker/manage.py test`
- `python jobtracker/manage.py migrate --fake-initial`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb154ad88330a5f6f2ab737dcab9