### PR TITLE
Handle existing Estimate table during migration

### DIFF
--- a/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
+++ b/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
@@ -18,14 +18,46 @@ def forward_migrate_estimates(apps, schema_editor):
     projects = Project.objects.filter(estimate_entries__isnull=False).distinct()
 
     for project in projects:
-        estimate = Estimate.objects.create(
+        estimate, _ = Estimate.objects.get_or_create(
             contractor=project.contractor,
             name=project.name,
-            created_date=project.start_date or django.utils.timezone.now().date(),
+            defaults={
+                "created_date": project.start_date
+                or django.utils.timezone.now().date(),
+            },
         )
         EstimateEntry.objects.filter(project=project).update(estimate=estimate)
         project.end_date = project.end_date or django.utils.timezone.now().date()
         project.save(update_fields=["end_date"])
+
+
+def create_estimate_table_if_missing(apps, schema_editor):
+    """Create ``tracker_estimate`` table when it doesn't already exist."""
+
+    if "tracker_estimate" in schema_editor.connection.introspection.table_names():
+        return
+    Estimate = type(
+        "Estimate",
+        (models.Model,),
+        {
+            "__module__": __name__,
+            "id": models.BigAutoField(primary_key=True, auto_created=True),
+            "name": models.CharField(max_length=255),
+            "created_date": models.DateField(default=django.utils.timezone.now),
+            "contractor": models.ForeignKey(
+                "tracker.Contractor",
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="estimates",
+            ),
+            "Meta": type(
+                "Meta",
+                (),
+                {"app_label": "migrations", "db_table": "tracker_estimate"},
+            ),
+        },
+    )
+
+    schema_editor.create_model(Estimate)
 
 
 class Migration(migrations.Migration):
@@ -36,31 +68,40 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.CreateModel(
-            name="Estimate",
-            fields=[
-                (
-                    "id",
-                    models.BigAutoField(
-                        auto_created=True,
-                        primary_key=True,
-                        serialize=False,
-                        verbose_name="ID",
-                    ),
-                ),
-                ("name", models.CharField(max_length=255)),
-                (
-                    "created_date",
-                    models.DateField(default=django.utils.timezone.now),
-                ),
-                (
-                    "contractor",
-                    models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE,
-                        related_name="estimates",
-                        to="tracker.contractor",
-                    ),
-                ),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.CreateModel(
+                    name="Estimate",
+                    fields=[
+                        (
+                            "id",
+                            models.BigAutoField(
+                                auto_created=True,
+                                primary_key=True,
+                                serialize=False,
+                                verbose_name="ID",
+                            ),
+                        ),
+                        ("name", models.CharField(max_length=255)),
+                        (
+                            "created_date",
+                            models.DateField(default=django.utils.timezone.now),
+                        ),
+                        (
+                            "contractor",
+                            models.ForeignKey(
+                                on_delete=django.db.models.deletion.CASCADE,
+                                related_name="estimates",
+                                to="tracker.contractor",
+                            ),
+                        ),
+                    ],
+                )
+            ],
+            database_operations=[
+                migrations.RunPython(
+                    create_estimate_table_if_missing, migrations.RunPython.noop
+                )
             ],
         ),
         migrations.AddField(


### PR DESCRIPTION
## Summary
- ensure Estimate table creation only runs when `tracker_estimate` is missing
- build a lightweight Estimate model in the migration to avoid registry conflicts
- remove unsupported `if_not_exists` usage in migration setup

## Testing
- `python jobtracker/manage.py test`
- `python jobtracker/manage.py migrate --fake-initial`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb154ad88330a5f6f2ab737dcab9