### PR TITLE
Handle existing Estimate table during migration

### DIFF
--- a/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
+++ b/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
@@ -18,14 +18,31 @@ def forward_migrate_estimates(apps, schema_editor):
     projects = Project.objects.filter(estimate_entries__isnull=False).distinct()
 
     for project in projects:
-        estimate = Estimate.objects.create(
+        estimate, _ = Estimate.objects.get_or_create(
             contractor=project.contractor,
             name=project.name,
-            created_date=project.start_date or django.utils.timezone.now().date(),
+            defaults={
+                "created_date": project.start_date
+                or django.utils.timezone.now().date(),
+            },
         )
         EstimateEntry.objects.filter(project=project).update(estimate=estimate)
         project.end_date = project.end_date or django.utils.timezone.now().date()
         project.save(update_fields=["end_date"])
+
+
+class CreateModelIfNotExists(migrations.CreateModel):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.name)
+        if model._meta.db_table in schema_editor.connection.introspection.table_names():
+            return
+        super().database_forwards(app_label, schema_editor, from_state, to_state)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.name)
+        if model._meta.db_table not in schema_editor.connection.introspection.table_names():
+            return
+        super().database_backwards(app_label, schema_editor, from_state, to_state)
 
 
 class Migration(migrations.Migration):
@@ -36,7 +53,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.CreateModel(
+        CreateModelIfNotExists(
             name="Estimate",
             fields=[
                 (


### PR DESCRIPTION
## Summary
- ensure Estimate table creation only runs when `tracker_estimate` is missing
- build a lightweight `CreateModelIfNotExists` operation to avoid unsupported parameters
- remove unsupported `if_not_exists` usage in migration setup

## Testing
- `python jobtracker/manage.py test`
- `python jobtracker/manage.py migrate --fake-initial`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb154ad88330a5f6f2ab737dcab9