### PR TITLE
Handle unsupported if_not_exists migration flag

### DIFF
--- a/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
+++ b/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
@@ -32,6 +32,10 @@ def forward_migrate_estimates(apps, schema_editor):
 
 
 class CreateModelIfNotExists(migrations.CreateModel):
+    def __init__(self, *args, **kwargs):
+        kwargs.pop("if_not_exists", None)
+        super().__init__(*args, **kwargs)
+
     def database_forwards(self, app_label, schema_editor, from_state, to_state):
         model = to_state.apps.get_model(app_label, self.name)
         if model._meta.db_table in schema_editor.connection.introspection.table_names():


### PR DESCRIPTION
## Summary
- allow custom `CreateModelIfNotExists` migration to accept and ignore `if_not_exists`

## Testing
- `python jobtracker/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0670190083308286392e57d16ac1