### PR TITLE
Handle orphan estimate entries in migration

### DIFF
--- a/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
+++ b/jobtracker/tracker/migrations/0008_remove_estimateentry_project_and_more.py
@@ -80,6 +80,16 @@ def forward_migrate_estimates(apps, schema_editor):
               AND (ee.estimate_id IS NULL)
             """
         )
+        # Since estimate data is non-critical, drop any lingering
+        # estimate entries that could not be associated with an
+        # Estimate. This prevents the subsequent NOT NULL constraint
+        # from failing during migration.
+        cur.execute(
+            """
+            DELETE FROM tracker_estimateentry
+            WHERE estimate_id IS NULL
+            """
+        )
 
 
 def reverse_migrate_estimates(apps, schema_editor):


### PR DESCRIPTION
## Summary
- Drop estimate entries with no estimate reference during migration to avoid NOT NULL errors

## Testing
- `python jobtracker/manage.py migrate --noinput` *(fails: sqlite3.OperationalError: near "DO": syntax error)*
- `python jobtracker/manage.py test tracker` *(fails: sqlite3.OperationalError: near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1bf9e0608330a660db0b93de53f6