### PR TITLE
Enable contractors to manage projects and estimates

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/estimate_list.html
+++ b/jobtracker/dashboard/templates/dashboard/estimate_list.html
@@ -38,6 +38,10 @@
                             {% csrf_token %}
                             <button type="submit" class="btn btn-sm btn-success">Accept</button>
                         </form>
+                        <form method="post" action="{% url 'dashboard:delete_estimate' estimate.pk %}" class="d-inline" onsubmit="return confirm('Delete this estimate?');">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                        </form>
                     </td>
                 </tr>
             {% empty %}

--- a/jobtracker/dashboard/templates/dashboard/project_list.html
+++ b/jobtracker/dashboard/templates/dashboard/project_list.html
@@ -17,6 +17,19 @@
     </div>
 </div>
 
+<form method="post" class="row g-3 mb-4">
+    {% csrf_token %}
+    <div class="col-auto">
+        <input type="text" name="name" id="add-project-name" class="form-control" placeholder="New project name">
+    </div>
+    <div class="col-auto">
+        <input type="date" name="start_date" class="form-control" value="{{ today|date:'Y-m-d' }}">
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-primary">Add Project</button>
+    </div>
+</form>
+
 {% if projects %}
 <div class="row">
     {% for project in projects %}
@@ -101,6 +114,12 @@
                         <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-outline-info btn-sm" title="Add Payment">
                             <i class="fas fa-money-bill-wave"></i>
                         </a>
+                        <form method="post" action="{% url 'dashboard:delete_project' project.pk %}" onsubmit="return confirm('Delete this project?');">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-outline-danger btn-sm" title="Delete Project">
+                                <i class="fas fa-trash"></i>
+                            </button>
+                        </form>
                     </div>
                 </div>
             </div>
@@ -154,15 +173,9 @@
             <p class="text-muted mb-4">
                 You don't have any active projects yet. Get started by creating your first project.
             </p>
-            {% if user.is_staff %}
-            <a href="{% url 'admin:tracker_project_add' %}" class="btn btn-primary btn-lg">
+            <a href="#" class="btn btn-primary btn-lg" onclick="document.getElementById('add-project-name').focus(); return false;">
                 <i class="fas fa-plus me-2"></i>Create Your First Project
             </a>
-            {% else %}
-            <p class="text-muted">
-                Contact your administrator to create projects.
-            </p>
-            {% endif %}
         </div>
     </div>
 </div>

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -712,3 +712,40 @@ class EstimateListTests(TestCase):
         self.assertTrue(
             self.contractor.projects.filter(name="Estimate").exists()
         )
+
+
+class ProjectEstimateCRUDTests(TestCase):
+    def setUp(self):
+        self.contractor = Contractor.objects.create(
+            name="Test Contractor", email="user@example.com"
+        )
+        ContractorUser.objects.create_user(
+            email="user@example.com", password="secret", contractor=self.contractor
+        )
+        self.client.post(
+            reverse("login"), {"username": "user@example.com", "password": "secret"}
+        )
+
+    def test_add_project_via_post(self):
+        response = self.client.post(
+            reverse("dashboard:project_list"),
+            {"name": "NewProj", "start_date": "2024-01-01"},
+        )
+        self.assertRedirects(response, reverse("dashboard:project_list"))
+        self.assertTrue(self.contractor.projects.filter(name="NewProj").exists())
+
+    def test_delete_project(self):
+        project = self.contractor.projects.create(name="Proj", start_date="2024-01-01")
+        response = self.client.post(
+            reverse("dashboard:delete_project", args=[project.pk])
+        )
+        self.assertRedirects(response, reverse("dashboard:project_list"))
+        self.assertFalse(self.contractor.projects.filter(pk=project.pk).exists())
+
+    def test_delete_estimate(self):
+        estimate = self.contractor.estimates.create(name="Est", created_date="2024-01-01")
+        response = self.client.post(
+            reverse("dashboard:delete_estimate", args=[estimate.pk])
+        )
+        self.assertRedirects(response, reverse("dashboard:estimate_list"))
+        self.assertFalse(self.contractor.estimates.filter(pk=estimate.pk).exists())

--- a/jobtracker/dashboard/urls.py
+++ b/jobtracker/dashboard/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path("", views.contractor_summary, name="contractor_summary"),
     path("projects/", views.project_list, name="project_list"),
     path("estimates/", views.estimate_list, name="estimate_list"),
+    path("estimates/<int:pk>/delete/", views.delete_estimate, name="delete_estimate"),
     path("estimates/<int:pk>/accept/", views.accept_estimate, name="accept_estimate"),
     path(
         "estimates/<int:pk>/add-entry/",
@@ -19,6 +20,7 @@ urlpatterns = [
         name="job_estimate_report",
     ),
     path("projects/<int:pk>/", views.project_detail, name="project_detail"),
+    path("projects/<int:pk>/delete/", views.delete_project, name="delete_project"),
     path(
         "projects/add-entry/select/",
         views.select_job_entry_project,


### PR DESCRIPTION
## Summary
- Allow contractors to create projects directly from the project list and to remove projects they no longer need.
- Introduce deletion capability for estimates and expose new endpoints for project and estimate removal.
- Add regression tests covering project creation plus project and estimate deletion workflows.

## Testing
- `pytest` *(no tests discovered)*
- `python jobtracker/manage.py test dashboard.tests.ProjectEstimateCRUDTests` *(fails: sqlite3.OperationalError: near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2cc0873883308eaa914343d956b9