### PR TITLE
Fix estimate creation form and add test

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/estimate_list.html
+++ b/jobtracker/dashboard/templates/dashboard/estimate_list.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="container mt-4">
     <h1 class="mb-4"><i class="fas fa-calculator me-2"></i>Estimator</h1>
-    <form method="post" class="row g-3 mb-4">
+    <form method="post" action="{% url 'dashboard:estimate_list' %}" class="row g-3 mb-4">
         {% csrf_token %}
         <div class="col-auto">
             <input type="text" name="name" class="form-control" placeholder="New estimate name">

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -731,6 +731,15 @@ class EstimateListTests(TestCase):
         self.assertContains(response, "$20.00")
         self.assertContains(response, "50.00%")
 
+    def test_add_estimate_creates_record(self):
+        self.client.force_login(self.user)
+        url = reverse("dashboard:estimate_list")
+        response = self.client.post(url, {"name": "New Est"})
+        self.assertRedirects(response, url)
+        self.assertTrue(
+            self.contractor.estimates.filter(name="New Est").exists()
+        )
+
     def test_accept_estimate_converts_to_project(self):
         self.client.force_login(self.user)
         url = reverse("dashboard:accept_estimate", args=[self.estimate.pk])


### PR DESCRIPTION
## Summary
- ensure Estimate list form posts to proper URL
- add regression test verifying new estimates can be created

## Testing
- `python manage.py test` *(fails: sqlite3.OperationalError: near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68ba33179ac48330892e142888a2bb84