### PR TITLE
fix: center weekly schedule on current day

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -518,6 +518,7 @@ window.SquireApp = {
 </script>
 
 <!-- Block for additional JavaScript -->
+<script src="{% static 'js/weekly_schedule.js' %}"></script>
 {% block extra_js %}{% endblock %}
 {% endif %}
 

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1968,3 +1968,17 @@ textarea.form-control {
         -webkit-overflow-scrolling: touch;
     }
 }
+
+/* Weekly schedule layout */
+.weekly-schedule {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+}
+.weekly-schedule > * {
+    scroll-snap-align: center;
+}
+.weekly-schedule .active {
+    background: var(--success-color);
+    color: var(--text-on-primary);
+}

--- a/jobtracker/static/js/weekly_schedule.js
+++ b/jobtracker/static/js/weekly_schedule.js
@@ -1,0 +1,31 @@
+/**
+ * Auto-centers the weekly schedule on the current day and ensures
+ * the highlighted date matches the displayed header.
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  const schedule = document.querySelector('.weekly-schedule');
+  if (!schedule) return;
+
+  const today = new Date();
+  const options = { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' };
+
+  const header = document.querySelector('.weekly-schedule-date');
+  if (header) {
+    header.textContent = today.toLocaleDateString(undefined, options);
+  }
+
+  let activeDay = null;
+  schedule.querySelectorAll('[data-date]').forEach((day) => {
+    const dayDate = new Date(day.dataset.date);
+    if (dayDate.toDateString() === today.toDateString()) {
+      day.classList.add('active');
+      activeDay = day;
+    } else {
+      day.classList.remove('active');
+    }
+  });
+
+  if (activeDay) {
+    activeDay.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+  }
+});


### PR DESCRIPTION
## Summary
- highlight and center current day in weekly schedule
- ensure schedule reflects local date

## Testing
- `python jobtracker/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bb5d28ef9c8330ba62ae3990aad4dc