### PR TITLE
Fix estimates date handling and queryset retrieval

### DIFF
--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -185,7 +185,7 @@ def estimate_list(request):
     if contractor is None:
         return redirect("login")
 
-    estimates = contractor.estimates.prefetch_related("entries")
+    estimates = contractor.estimates.all().prefetch_related("entries")
     
     # Calculate totals and summary statistics
     total_value = Decimal("0")

--- a/jobtracker/tracker/models.py
+++ b/jobtracker/tracker/models.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from PIL import Image
 import os
 from django.utils import timezone
+from datetime import datetime
 
 
 class GlobalSettings(models.Model):
@@ -203,6 +204,12 @@ class Estimate(models.Model):
         return f"{self.estimate_number or self.name} - {self.customer_name}"
 
     def save(self, *args, **kwargs):
+        if isinstance(self.created_date, str):
+            try:
+                self.created_date = datetime.strptime(self.created_date, "%Y-%m-%d").date()
+            except ValueError:
+                self.created_date = timezone.now().date()
+
         # Auto-generate estimate number if not provided
         if not self.estimate_number:
             year = self.created_date.year


### PR DESCRIPTION
## Summary
- Ensure `Estimate.save` converts string dates to `datetime.date`
- Retrieve contractor estimates via `all().prefetch_related("entries")` for reliable queryset evaluation

## Testing
- `python manage.py test` *(fails: sqlite3.OperationalError near "DO" in migration)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc844d28c8330ac628803c57cb1d6