### PR TITLE
Fix estimate form navigation

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/create_estimate.html
+++ b/jobtracker/dashboard/templates/dashboard/create_estimate.html
@@ -683,7 +683,7 @@ function calculateRowTotal(element) {
     const qty = parseFloat(row.querySelector('input[name="material_quantity[]"]').value) || 0;
     const cost = parseFloat(row.querySelector('input[name="material_cost[]"]').value) || 0;
     const total = qty * cost;
-    row.querySelector('.material-total').textContent = ' + total.toFixed(2);
+    row.querySelector('.material-total').textContent = '$' + total.toFixed(2);
     updateTotals();
 }
 
@@ -716,7 +716,7 @@ function calculateServiceRowTotal(element) {
     const cost = parseFloat(row.querySelector('input[name="service_cost[]"]').value) || 0;
     const markup = parseFloat(row.querySelector('input[name="service_markup[]"]').value) || 0;
     const total = qty * cost * (1 + markup / 100);
-    row.querySelector('.service-total').textContent = ' + total.toFixed(2);
+    row.querySelector('.service-total').textContent = '$' + total.toFixed(2);
     updateTotals();
 }
 
@@ -753,7 +753,7 @@ function updateTotals() {
         
         laborTotal += rowTotal;
         laborCost += rowCost;
-        row.querySelector('.entry-total').textContent = ' + rowTotal.toFixed(2);
+        row.querySelector('.entry-total').textContent = '$' + rowTotal.toFixed(2);
     });
     
     // Calculate materials total
@@ -767,7 +767,7 @@ function updateTotals() {
         const margin = {{ margin|default:25 }} / 100;
         materialsTotal += total / (1 - margin);
         
-        row.querySelector('.material-total').textContent = ' + (total / (1 - margin)).toFixed(2);
+        row.querySelector('.material-total').textContent = '$' + (total / (1 - margin)).toFixed(2);
     });
 
     // Calculate services total
@@ -781,7 +781,7 @@ function updateTotals() {
         servicesCost += total;
         servicesTotal += billableTotal;
         
-        row.querySelector('.service-total').textContent = ' + billableTotal.toFixed(2);
+        row.querySelector('.service-total').textContent = '$' + billableTotal.toFixed(2);
     });
 
     const grandTotal = laborTotal + materialsTotal + servicesTotal;
@@ -790,17 +790,17 @@ function updateTotals() {
     const margin = grandTotal > 0 ? (profit / grandTotal * 100) : 0;
 
     // Update display
-    document.getElementById('labor-total').textContent = ' + laborTotal.toFixed(2);
-    document.getElementById('materials-total').textContent = ' + materialsTotal.toFixed(2);
-    document.getElementById('services-total').textContent = ' + servicesTotal.toFixed(2);
-    document.getElementById('grand-total').textContent = ' + grandTotal.toFixed(2);
-    document.getElementById('total-billable').textContent = ' + grandTotal.toFixed(2);
-    document.getElementById('profit-total').textContent = ' + profit.toFixed(2);
+    document.getElementById('labor-total').textContent = '$' + laborTotal.toFixed(2);
+    document.getElementById('materials-total').textContent = '$' + materialsTotal.toFixed(2);
+    document.getElementById('services-total').textContent = '$' + servicesTotal.toFixed(2);
+    document.getElementById('grand-total').textContent = '$' + grandTotal.toFixed(2);
+    document.getElementById('total-billable').textContent = '$' + grandTotal.toFixed(2);
+    document.getElementById('profit-total').textContent = '$' + profit.toFixed(2);
     document.getElementById('margin-percent').textContent = margin.toFixed(1) + '%';
     
     // Update review totals
-    document.getElementById('review-total').textContent = ' + grandTotal.toFixed(2);
-    document.getElementById('review-profit').textContent = ' + profit.toFixed(2);
+    document.getElementById('review-total').textContent = '$' + grandTotal.toFixed(2);
+    document.getElementById('review-profit').textContent = '$' + profit.toFixed(2);
     document.getElementById('review-margin').textContent = margin.toFixed(1) + '%';
 }
 


### PR DESCRIPTION
## Summary
- fix JavaScript syntax in estimate creation template so totals show currency and navigation functions load

## Testing
- `python manage.py test` *(fails: sqlite3.OperationalError: near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd2952080833081f663215a98b256