### PR TITLE
Fix estimate creation without date

### DIFF
--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -786,3 +786,15 @@ class ProjectEstimateCRUDTests(TestCase):
         )
         self.assertRedirects(response, reverse("dashboard:estimate_list"))
         self.assertFalse(self.contractor.estimates.filter(pk=estimate.pk).exists())
+
+    def test_create_estimate_without_created_date(self):
+        response = self.client.post(
+            reverse("dashboard:create_estimate"),
+            {
+                "name": "NoDate",
+                "customer_name": "Customer",
+                "project_location": "Site",
+            },
+        )
+        self.assertRedirects(response, reverse("dashboard:estimate_list"))
+        self.assertTrue(self.contractor.estimates.filter(name="NoDate").exists())

--- a/jobtracker/dashboard/views.py
+++ b/jobtracker/dashboard/views.py
@@ -1320,6 +1320,17 @@ def create_estimate(request):
     employees = contractor.employees.all()
 
     if request.method == "POST":
+        # Normalize the created date; fall back to today if missing or invalid
+        created_date_str = request.POST.get("created_date")
+        try:
+            created_date = (
+                datetime.strptime(created_date_str, "%Y-%m-%d").date()
+                if created_date_str
+                else timezone.now().date()
+            )
+        except ValueError:
+            created_date = timezone.now().date()
+
         # Create the estimate
         estimate = Estimate.objects.create(
             contractor=contractor,
@@ -1336,12 +1347,12 @@ def create_estimate(request):
             special_terms=request.POST.get("special_terms", ""),
             liability_statement=request.POST.get("liability_statement", ""),
             notes=request.POST.get("notes", ""),
-            created_date=request.POST.get("created_date"),
+            created_date=created_date,
             valid_until=request.POST.get("valid_until") or None,
         )
 
         entries_created = 0
-        date = request.POST.get("created_date")
+        date = created_date
 
         # Process labor/equipment entries
         hours_list = request.POST.getlist("hours[]")


### PR DESCRIPTION
## Summary
- prevent 500 when creating estimate without a date by defaulting to today's date
- test creating an estimate without a provided date

## Testing
- `python manage.py test` (fails: OperationalError near "DO" – migrations require PostgreSQL)


------
https://chatgpt.com/codex/tasks/task_e_68bce8fed1ac8330bface6f69014edc1