### PR TITLE
Fix total price overflow in labor entry forms

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/create_estimate.html
+++ b/jobtracker/dashboard/templates/dashboard/create_estimate.html
@@ -610,7 +610,7 @@ function addLaborEntry() {
             </button>
         </div>
         <div class="row g-3">
-            <div class="col-md-3">
+            <div class="col-md-2">
                 <label class="form-label">Hours/Quantity</label>
                 <input type="number" class="form-control" name="hours[]" step="0.25" placeholder="0.00" onchange="updateTotals()">
             </div>
@@ -636,7 +636,7 @@ function addLaborEntry() {
                     {% endfor %}
                 </select>
             </div>
-            <div class="col-md-1 d-flex align-items-end">
+            <div class="col-md-2 d-flex align-items-end justify-content-end">
                 <div class="text-success fw-bold entry-total">$0.00</div>
             </div>
             <div class="col-12">

--- a/jobtracker/dashboard/templates/dashboard/edit_estimate.html
+++ b/jobtracker/dashboard/templates/dashboard/edit_estimate.html
@@ -140,7 +140,7 @@
                                         </button>
                                     </div>
                                     <div class="row g-3">
-                                        <div class="col-md-3">
+                                        <div class="col-md-2">
                                             <label class="form-label">Hours/Quantity</label>
                                             <input type="number" class="form-control" name="hours[]" step="0.25" value="{{ entry.hours }}" onchange="updateTotals()">
                                         </div>
@@ -166,7 +166,7 @@
                                                 {% endfor %}
                                             </select>
                                         </div>
-                                        <div class="col-md-1 d-flex align-items-end">
+                                        <div class="col-md-2 d-flex align-items-end justify-content-end">
                                             <div class="text-success fw-bold entry-total">${{ entry.billable_amount|floatformat:2 }}</div>
                                         </div>
                                         <div class="col-12">
@@ -512,7 +512,7 @@ function addLaborEntry() {
             </button>
         </div>
         <div class="row g-3">
-            <div class="col-md-3">
+            <div class="col-md-2">
                 <label class="form-label">Hours/Quantity</label>
                 <input type="number" class="form-control" name="hours[]" step="0.25" placeholder="0.00" onchange="updateTotals()">
             </div>
@@ -538,7 +538,7 @@ function addLaborEntry() {
                     {% endfor %}
                 </select>
             </div>
-            <div class="col-md-1 d-flex align-items-end">
+            <div class="col-md-2 d-flex align-items-end justify-content-end">
                 <div class="text-success fw-bold entry-total">$0.00</div>
             </div>
             <div class="col-12">

--- a/jobtracker/dashboard/templates/dashboard/estimate_form.html
+++ b/jobtracker/dashboard/templates/dashboard/estimate_form.html
@@ -449,7 +449,7 @@ function addLaborEntry() {
             </button>
         </div>
         <div class="row g-3">
-            <div class="col-md-3">
+            <div class="col-md-2">
                 <label class="form-label">Hours/Quantity</label>
                 <input type="number" class="form-control" name="hours[]" step="0.25" placeholder="0.00" onchange="updateTotals()">
             </div>
@@ -475,7 +475,7 @@ function addLaborEntry() {
                     {% endfor %}
                 </select>
             </div>
-            <div class="col-md-1 d-flex align-items-end">
+            <div class="col-md-2 d-flex align-items-end justify-content-end">
                 <div class="text-success fw-bold entry-total">$0.00</div>
             </div>
             <div class="col-12">

--- a/jobtracker/dashboard/templates/dashboard/jobentry_form.html
+++ b/jobtracker/dashboard/templates/dashboard/jobentry_form.html
@@ -368,7 +368,7 @@ function addLaborEntry() {
             </button>
         </div>
         <div class="row g-3">
-            <div class="col-md-3">
+            <div class="col-md-2">
                 <label class="form-label">Hours/Quantity</label>
                 <input type="number" class="form-control" name="hours[]" step="0.25" placeholder="0.00" onchange="updateTotals()">
             </div>
@@ -394,7 +394,7 @@ function addLaborEntry() {
                     {% endfor %}
                 </select>
             </div>
-            <div class="col-md-1 d-flex align-items-end">
+            <div class="col-md-2 d-flex align-items-end justify-content-end">
                 <div class="text-success fw-bold entry-total">$0.00</div>
             </div>
             <div class="col-12">


### PR DESCRIPTION
## Summary
- prevent labor entry total from overflowing its container
- adjust column widths for hours and total in labor entry rows

## Testing
- `python manage.py test` *(fails: OperationalError near "DO")*

------
https://chatgpt.com/codex/tasks/task_e_68bf41e6eee08330a826cf603fe10b31