### PR TITLE
Fix estimate breakdown card totals not updating

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/edit_estimate.html
+++ b/jobtracker/dashboard/templates/dashboard/edit_estimate.html
@@ -599,7 +599,7 @@ function calculateRowTotal(element) {
     const margin = {{ margin|default:25 }} / 100;
     const billableTotal = total / (1 - margin);
     
-    row.querySelector('.material-total').textContent = ' + billableTotal.toFixed(2);
+    row.querySelector('.material-total').textContent = '$' + billableTotal.toFixed(2);
     updateTotals();
 }
 
@@ -642,7 +642,7 @@ function calculateServiceRowTotal(element) {
     const cost = parseFloat(row.querySelector('input[name="service_cost[]"]').value) || 0;
     const markup = parseFloat(row.querySelector('input[name="service_markup[]"]').value) || 0;
     const total = qty * cost * (1 + markup / 100);
-    row.querySelector('.service-total').textContent = ' + total.toFixed(2);
+    row.querySelector('.service-total').textContent = '$' + total.toFixed(2);
     updateTotals();
 }
 
@@ -679,14 +679,14 @@ function updateTotals() {
         
         laborTotal += rowTotal;
         laborCost += rowCost;
-        row.querySelector('.entry-total').textContent = ' + rowTotal.toFixed(2);
+        row.querySelector('.entry-total').textContent = '$' + rowTotal.toFixed(2);
     });
     
     // Calculate materials total
     document.querySelectorAll('#materialsTable tbody tr').forEach(row => {
         const totalText = row.querySelector('.material-total')?.textContent;
         if (totalText) {
-            const total = parseFloat(totalText.replace(', '')) || 0;
+            const total = parseFloat(totalText.replace(/[$,]/g, '')) || 0;
             materialsTotal += total;
             
             // Calculate cost
@@ -700,7 +700,7 @@ function updateTotals() {
     document.querySelectorAll('#servicesTable tbody tr').forEach(row => {
         const totalText = row.querySelector('.service-total')?.textContent;
         if (totalText) {
-            const total = parseFloat(totalText.replace(', '')) || 0;
+            const total = parseFloat(totalText.replace(/[$,]/g, '')) || 0;
             servicesTotal += total;
             
             // Calculate cost
@@ -716,12 +716,12 @@ function updateTotals() {
     const margin = grandTotal > 0 ? (profit / grandTotal * 100) : 0;
 
     // Update display
-    document.getElementById('labor-total').textContent = ' + laborTotal.toFixed(2);
-    document.getElementById('materials-total').textContent = ' + materialsTotal.toFixed(2);
-    document.getElementById('services-total').textContent = ' + servicesTotal.toFixed(2);
-    document.getElementById('grand-total').textContent = ' + grandTotal.toFixed(2);
-    document.getElementById('total-billable').textContent = ' + grandTotal.toFixed(2);
-    document.getElementById('profit-total').textContent = ' + profit.toFixed(2);
+    document.getElementById('labor-total').textContent = '$' + laborTotal.toFixed(2);
+    document.getElementById('materials-total').textContent = '$' + materialsTotal.toFixed(2);
+    document.getElementById('services-total').textContent = '$' + servicesTotal.toFixed(2);
+    document.getElementById('grand-total').textContent = '$' + grandTotal.toFixed(2);
+    document.getElementById('total-billable').textContent = '$' + grandTotal.toFixed(2);
+    document.getElementById('profit-total').textContent = '$' + profit.toFixed(2);
     document.getElementById('margin-percent').textContent = margin.toFixed(1) + '%';
 }
 
@@ -748,6 +748,7 @@ window.addServiceRow = addServiceRow;
 window.bulkAddServices = bulkAddServices;
 window.removeServiceRow = removeServiceRow;
 window.calculateServiceRowTotal = calculateServiceRowTotal;
+document.addEventListener('DOMContentLoaded', updateTotals);
 </script>
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- Format line item totals with currency symbols
- Parse material and service totals correctly and update breakdown display
- Recalculate totals on page load to show current estimate values

## Testing
- `python manage.py test` *(fails: sqlite3.OperationalError: near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4250cb9883308f885da79bd92e25