### PR TITLE
Open PDF report exports in new tab

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
@@ -354,7 +354,7 @@ body {
 <div class="d-print-none mb-4">
     <div class="d-flex justify-content-between align-items-center">
         <div>
-            <a href="?export=pdf" class="btn btn-secondary">
+            <a href="?export=pdf" class="btn btn-secondary" target="_blank" rel="noopener">
                 <i class="fas fa-file-pdf me-2"></i>Download PDF
             </a>
         </div>

--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -511,7 +511,7 @@ body {
 <div class="d-print-none mb-4">
     <div class="d-flex justify-content-between align-items-center">
         <div>
-            <a href="?export=pdf" class="btn btn-secondary">
+            <a href="?export=pdf" class="btn btn-secondary" target="_blank" rel="noopener">
                 <i class="fas fa-file-pdf me-2"></i>Download PDF
             </a>
         </div>

--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -496,7 +496,7 @@ body {
 <div class="d-print-none mb-4">
     <div class="d-flex justify-content-between align-items-center">
         <div>
-            <a href="?export=pdf" class="btn btn-secondary">
+            <a href="?export=pdf" class="btn btn-secondary" target="_blank" rel="noopener">
                 <i class="fas fa-file-pdf me-2"></i>Download PDF
             </a>
         </div>

--- a/jobtracker/dashboard/templates/dashboard/job_estimate_report.html
+++ b/jobtracker/dashboard/templates/dashboard/job_estimate_report.html
@@ -6,7 +6,7 @@
     <h1 class="mb-3"><i class="fas fa-file-invoice-dollar me-2"></i>Job Estimate</h1>
     <h4 class="mb-4">{{ estimate.name }}</h4>
     {% if not report %}
-    <a href="?export=pdf" class="btn btn-secondary mb-3">
+    <a href="?export=pdf" class="btn btn-secondary mb-3" target="_blank" rel="noopener">
         <i class="fas fa-file-pdf me-2"></i>Download PDF
     </a>
     {% endif %}


### PR DESCRIPTION
## Summary
- ensure PDF exports open in a new tab/window across job and contractor reports

## Testing
- `python manage.py test` *(fails: OperationalError: near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bf463df2fc833090c5d30256d96590