### PR TITLE
Adjust navbar z-index to keep estimate sidebar beneath header

### DIFF
--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -380,7 +380,7 @@ textarea:focus {
     padding: 16px 0;
     position: sticky;
     top: 0;
-    z-index: 1000;
+    z-index: 1030;
 }
 
 .navbar-brand {


### PR DESCRIPTION
## Summary
- Increase navbar z-index so floating sidebar cards on edit estimate view stay beneath the sticky header

## Testing
- `python manage.py test` *(fails: sqlite3.OperationalError: near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bf775fbea08330b05ea808fda2e79b