### PR TITLE
Ensure estimate sidebar respects sticky navbar

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/edit_estimate.html
+++ b/jobtracker/dashboard/templates/dashboard/edit_estimate.html
@@ -391,7 +391,7 @@
     
     <!-- Summary Sidebar -->
     <div class="col-lg-3">
-        <div class="sticky-top" style="top: 100px;">
+        <div class="estimate-sidebar">
             <!-- Current Totals -->
             <div class="card mb-3">
                 <div class="card-header bg-success text-white text-center">

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -380,7 +380,7 @@ textarea:focus {
     padding: 16px 0;
     position: sticky;
     top: 0;
-    z-index: 1000;
+    z-index: 1030;
 }
 
 .navbar-brand {
@@ -425,6 +425,13 @@ textarea:focus {
     height: fit-content;
     position: sticky;
     top: 100px;
+}
+
+/* Estimate edit sidebar */
+.estimate-sidebar {
+    position: sticky;
+    top: 80px;
+    z-index: 900;
 }
 
 .sidebar-item {


### PR DESCRIPTION
## Summary
- Introduce dedicated `estimate-sidebar` class for edit estimate sidebar
- Set sticky offset and lower z-index so sidebar remains below navbar while scrolling

## Testing
- `python jobtracker/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bf775fbea08330b05ea808fda2e79b