### PR TITLE
Prevent PWA lock-up on PDF downloads

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -517,6 +517,8 @@ window.SquireApp = {
 };
 </script>
 
+<script src="{% static 'js/pwa.js' %}"></script>
+
 <!-- Block for additional JavaScript -->
 {% block extra_js %}{% endblock %}
 {% endif %}

--- a/jobtracker/static/js/pwa.js
+++ b/jobtracker/static/js/pwa.js
@@ -1,0 +1,57 @@
+// Enhancements for PWA environment
+// Intercepts PDF download links so the app doesn't navigate away
+// and triggers a direct download instead. This avoids trapping users
+// on a PDF page without navigation.
+
+document.addEventListener('DOMContentLoaded', function () {
+    if (!window.matchMedia('(display-mode: standalone)').matches) {
+        return; // Not running as installed PWA
+    }
+
+    document.querySelectorAll('a[download]').forEach(function (link) {
+        link.addEventListener('click', function (e) {
+            e.preventDefault();
+
+            fetch(link.href)
+                .then(function (res) {
+                    const disposition = res.headers.get('Content-Disposition');
+                    let filename = 'report.pdf';
+                    if (disposition && disposition.includes('filename=')) {
+                        const match = disposition.match(/filename="?([^";]+)"?/);
+                        if (match && match[1]) {
+                            filename = match[1];
+                        }
+                    }
+                    return res.blob().then(function (blob) {
+                        return { blob: blob, filename: filename };
+                    });
+                })
+                .then(async function (data) {
+                    const file = new File([data.blob], data.filename, {
+                        type: 'application/pdf'
+                    });
+
+                    if (navigator.share && navigator.canShare && navigator.canShare({ files: [file] })) {
+                        try {
+                            await navigator.share({ files: [file] });
+                            return; // Shared successfully; nothing else to do
+                        } catch (shareErr) {
+                            console.error('PWA PDF share failed', shareErr);
+                        }
+                    }
+
+                    const url = URL.createObjectURL(data.blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = data.filename;
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                    URL.revokeObjectURL(url);
+                })
+                .catch(function (err) {
+                    console.error('PWA PDF download failed', err);
+                });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add client-side handler to fetch PDF blobs and trigger downloads when running as an installed PWA, keeping users on the page
- Load new PWA script in base template so PDF links work without navigation
- Share PDFs via the Web Share API when available to avoid exposing blob links in messages

## Testing
- `python jobtracker/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bf7d6410ec8330b96906ca25c1877d