### PR TITLE
Improve mobile layout for customer estimate header

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/customer_estimate_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_estimate_report.html
@@ -4,15 +4,12 @@
 {% block content %}
 
 {% if not report %}
-<div class="d-flex justify-content-between align-items-center mb-4 d-print-none">
-    <div>
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4 d-print-none">
+    <div class="mb-3 mb-md-0">
         <h1 class="mb-2">Customer Estimate</h1>
         <p class="text-muted mb-0">{{ estimate.estimate_number }} - {{ estimate.customer_name }}</p>
     </div>
-    <div class="d-flex gap-2">
-        <a href="{% url 'dashboard:estimate_list' %}" class="btn btn-outline-secondary">
-            <i class="fas fa-arrow-left me-2"></i>Back to Estimates
-        </a>
+    <div class="d-flex">
         <a href="?export=pdf" class="btn btn-primary" target="_blank" rel="noopener noreferrer" download>
             <i class="fas fa-file-pdf me-2"></i>Download PDF
         </a>


### PR DESCRIPTION
## Summary
- Stack the customer estimate header vertically on small screens
- Keep action buttons grouped beneath header info for clearer mobile layout
- Remove redundant back navigation button in customer estimate report

## Testing
- `python jobtracker/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bf8201c7a48330940a64a77ed804de