### PR TITLE
Improve mobile layout for customer estimate header

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/create_estimate.html
+++ b/jobtracker/dashboard/templates/dashboard/create_estimate.html
@@ -3,8 +3,8 @@
 {% block title %}Create Estimates{% endblock %}
 {% block content %}
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <div>
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4">
+    <div class="mb-3 mb-md-0">
         <h1 class="mb-2">
             <i class="fas fa-calculator me-3"></i>Create Estimates
         </h1>

--- a/jobtracker/dashboard/templates/dashboard/customer_estimate_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_estimate_report.html
@@ -4,15 +4,12 @@
 {% block content %}
 
 {% if not report %}
-<div class="d-flex justify-content-between align-items-center mb-4 d-print-none">
-    <div>
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4 d-print-none">
+    <div class="mb-3 mb-md-0">
         <h1 class="mb-2">Customer Estimate</h1>
         <p class="text-muted mb-0">{{ estimate.estimate_number }} - {{ estimate.customer_name }}</p>
     </div>
-    <div class="d-flex gap-2">
-        <a href="{% url 'dashboard:estimate_list' %}" class="btn btn-outline-secondary">
-            <i class="fas fa-arrow-left me-2"></i>Back to Estimates
-        </a>
+    <div class="d-flex">
         <a href="?export=pdf" class="btn btn-primary" target="_blank" rel="noopener noreferrer" download>
             <i class="fas fa-file-pdf me-2"></i>Download PDF
         </a>

--- a/jobtracker/dashboard/templates/dashboard/edit_estimate.html
+++ b/jobtracker/dashboard/templates/dashboard/edit_estimate.html
@@ -3,8 +3,8 @@
 {% block title %}Edit Estimate - {{ estimate.estimate_number }}{% endblock %}
 {% block content %}
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <div>
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4">
+    <div class="mb-3 mb-md-0">
         <h1 class="mb-2">
             <i class="fas fa-edit me-3"></i>Edit Estimate
         </h1>

--- a/jobtracker/dashboard/templates/dashboard/estimate_form.html
+++ b/jobtracker/dashboard/templates/dashboard/estimate_form.html
@@ -3,8 +3,8 @@
 {% block title %}Add Estimate Entry{% endblock %}
 {% block content %}
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <div>
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4">
+    <div class="mb-3 mb-md-0">
         <h1 class="mb-2">
             <i class="fas fa-calendar-plus me-3"></i>Job Estimate Entry
         </h1>

--- a/jobtracker/dashboard/templates/dashboard/estimate_list.html
+++ b/jobtracker/dashboard/templates/dashboard/estimate_list.html
@@ -3,8 +3,8 @@
 {% block title %}Estimates{% endblock %}
 {% block content %}
 
-<div class="d-flex justify-content-between align-items-center mb-4">
-    <div>
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4">
+    <div class="mb-3 mb-md-0">
         <h1 class="mb-2">
             <i class="fas fa-calculator me-3"></i>Estimates
         </h1>

--- a/jobtracker/dashboard/templates/dashboard/internal_estimate_report.html
+++ b/jobtracker/dashboard/templates/dashboard/internal_estimate_report.html
@@ -4,15 +4,12 @@
 {% block content %}
 
 {% if not report %}
-<div class="d-flex justify-content-between align-items-center mb-4 d-print-none">
-    <div>
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4 d-print-none">
+    <div class="mb-3 mb-md-0">
         <h1 class="mb-2">Internal Estimate Analysis</h1>
         <p class="text-muted mb-0">{{ estimate.estimate_number }} - {{ estimate.customer_name }}</p>
     </div>
-    <div class="d-flex gap-2">
-        <a href="{% url 'dashboard:estimate_list' %}" class="btn btn-outline-secondary">
-            <i class="fas fa-arrow-left me-2"></i>Back to Estimates
-        </a>
+    <div class="d-flex">
         <a href="?export=pdf" class="btn btn-primary" target="_blank" rel="noopener noreferrer" download>
             <i class="fas fa-file-pdf me-2"></i>Download PDF
         </a>

--- a/jobtracker/dashboard/templates/dashboard/job_estimate_report.html
+++ b/jobtracker/dashboard/templates/dashboard/job_estimate_report.html
@@ -3,13 +3,19 @@
 {% block title %}Job Estimate{% endblock %}
 {% block content %}
 <div class="container mt-4">
-    <h1 class="mb-3"><i class="fas fa-file-invoice-dollar me-2"></i>Job Estimate</h1>
-    <h4 class="mb-4">{{ estimate.name }}</h4>
-    {% if not report %}
-    <a href="?export=pdf" class="btn btn-secondary mb-3" target="_blank" rel="noopener noreferrer" download>
-        <i class="fas fa-file-pdf me-2"></i>Download PDF
-    </a>
-    {% endif %}
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center mb-4">
+        <div class="mb-3 mb-md-0">
+            <h1 class="mb-2"><i class="fas fa-file-invoice-dollar me-2"></i>Job Estimate</h1>
+            <p class="text-muted mb-0">{{ estimate.name }}</p>
+        </div>
+        {% if not report %}
+        <div class="d-flex">
+            <a href="?export=pdf" class="btn btn-secondary" target="_blank" rel="noopener noreferrer" download>
+                <i class="fas fa-file-pdf me-2"></i>Download PDF
+            </a>
+        </div>
+        {% endif %}
+    </div>
     <div class="table-responsive">
         <table class="table table-bordered w-auto">
             <thead class="table-light">


### PR DESCRIPTION
## Summary
- Stack the customer estimate header vertically on small screens
- Keep action buttons grouped beneath header info for clearer mobile layout
- Remove redundant back navigation button in customer estimate report

## Testing
- `python jobtracker/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bf8201c7a48330940a64a77ed804de