### PR TITLE
Fix materials tab visibility on mobile job entry

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/base.html
+++ b/jobtracker/dashboard/templates/dashboard/base.html
@@ -354,7 +354,12 @@ document.addEventListener('DOMContentLoaded', function () {
         if (window.innerWidth <= 576) {
             ths.forEach(function (th, index) {
                 const cells = Array.from(table.querySelectorAll('tbody tr')).map(row => row.children[index]);
-                const hasContent = cells.some(cell => cell && cell.textContent.trim() !== '' && cell.textContent.trim() !== '—');
+                const hasContent = cells.some(cell => {
+                    if (!cell) return false;
+                    const text = cell.textContent.trim();
+                    if (text !== '' && text !== '—') return true;
+                    return !!cell.querySelector('input, select, textarea, button');
+                });
                 
                 if (!hasContent) {
                     th.style.display = 'none';


### PR DESCRIPTION
## Summary
- Ensure responsive table script treats cells with form controls as populated so entry columns aren't hidden on mobile

## Testing
- `python jobtracker/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bf84caecb483309e95a42bc80bd98c