### PR TITLE
Align primary theme with info gradient

### DIFF
--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1,19 +1,19 @@
 /* Enhanced Squire Enterprises CSS with Optimized UX Design */
 
 :root {
-    /* Emerald Primary Gradient - matching Today's Totals */
-    --primary-gradient: linear-gradient(135deg, #228b22 0%, #32cd32 100%);
+    /* Primary gradient inherits the info gradient for consistency */
+    --primary-gradient: var(--info-gradient);
     
     /* Complementary gradients */
     --secondary-gradient: linear-gradient(135deg, #8b4513 0%, #a0522d 100%); /* Warm brown */
-    --success-gradient: linear-gradient(135deg, #228b22 0%, #32cd32 100%); /* Bright green */
+    --success-gradient: var(--info-gradient); /* Align success with info gradient */
     --warning-gradient: linear-gradient(135deg, #daa520 0%, #ffd700 100%); /* Golden yellow */
     --info-gradient: linear-gradient(135deg, #2e8b57 0%, #3cb371 100%); /* Sea green */
     --danger-gradient: linear-gradient(135deg, #8b4513 0%, #cd853f 100%); /* Rustic brown */
     
     /* Core colors */
-    --primary-color: #32cd32; /* Emerald green */
-    --secondary-color: #32cd32; /* Emerald green */
+    --primary-color: #3cb371; /* Medium sea green */
+    --secondary-color: #3cb371; /* Medium sea green */
     --accent-color: #32cd32; /* Emerald accent */
     --warm-accent: #daa520; /* Golden accent */
     

--- a/jobtracker/templates/admin/base_site.html
+++ b/jobtracker/templates/admin/base_site.html
@@ -300,18 +300,10 @@
         
         .addlink:hover,
         .changelink:hover {
-            background: #1e7e1e !important;
+            background: var(--primary-color) !important;
             color: white !important;
             transform: translateY(-1px) !important;
-            box-shadow: 0 4px 8px rgba(34, 139, 34, 0.3) !important;
-        }
-        
-        .changelink {
-            background: #2e8b57 !important;
-        }
-        
-        .changelink:hover {
-            background: #26704c !important;
+            box-shadow: 0 4px 8px rgba(60, 179, 113, 0.3) !important;
         }
         
         /* Force white text on buttons */


### PR DESCRIPTION
## Summary
- use info gradient for primary and success styles
- centralize green button colors on admin base template

## Testing
- `python manage.py test` *(fails: OperationalError near "DO")*

------
https://chatgpt.com/codex/tasks/task_e_68bf8cd72ae08330a7d05e3914690714