### PR TITLE
Make job detail tabs mobile friendly

### DIFF
--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1349,14 +1349,18 @@ textarea:focus {
 
 @media (max-width: 576px) {
     .nav-tabs-custom {
-        flex-wrap: nowrap;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
+        flex-wrap: wrap;
+        overflow-x: visible;
+    }
+
+    .nav-tabs-custom .nav-item {
+        flex: 0 0 50%;
     }
 
     .nav-tabs-custom .nav-link {
-        white-space: nowrap;
-        flex: 0 0 auto;
+        width: 100%;
+        margin-right: 0;
+        margin-bottom: 10px;
     }
 }
 


### PR DESCRIPTION
## Summary
- Allow job detail nav tabs to wrap on small screens so all tabs are visible without horizontal scrolling

## Testing
- `python manage.py test` *(fails: django.db.utils.OperationalError: near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8e973dfc83309cbaf8fca296ca00