### PR TITLE
style: diversify dashboard action colors

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_job_report.html
@@ -570,7 +570,7 @@ body {
                 <a href="{% url 'dashboard:add_job_entry' project.pk %}" class="btn btn-outline-warning">
                     <i class="fas fa-plus me-2"></i>Add Entry
                 </a>
-                <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-outline-info">
+                <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-outline-primary">
                     <i class="fas fa-money-bill-wave me-2"></i>Add Payment
                 </a>
             </div>

--- a/jobtracker/dashboard/templates/dashboard/contractor_report.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_report.html
@@ -627,7 +627,7 @@ body {
                     </span>
                 </td>
                 <td class="text-right" data-label="Billable Total">
-                    <span class="{% if report %}amount revenue{% else %}text-primary fw-semibold{% endif %}">
+                    <span class="{% if report %}amount revenue{% else %}text-success fw-semibold{% endif %}">
                         ${{ p.total_billable|default:0|floatformat:2|intcomma }}
                     </span>
                 </td>

--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -17,14 +17,14 @@
 <!-- Quick Actions -->
 <div class="row mb-4">
     <div class="col-md-3 mb-3">
-        <div class="quick-action-card primary" onclick="location.href='{% url 'dashboard:select_job_entry_project' %}'">
+        <div class="quick-action-card success" onclick="location.href='{% url 'dashboard:select_job_entry_project' %}'">
             <i class="fas fa-plus-circle quick-action-icon"></i>
             <h5 class="mb-2">New Job Entry</h5>
             <p class="mb-0">Log today's work</p>
         </div>
     </div>
     <div class="col-md-3 mb-3">
-        <div class="quick-action-card success" onclick="location.href='{% url 'dashboard:select_payment_project' %}'">
+        <div class="quick-action-card primary" onclick="location.href='{% url 'dashboard:select_payment_project' %}'">
             <i class="fas fa-money-bill-wave quick-action-icon"></i>
             <h5 class="mb-2">Record Payment</h5>
             <p class="mb-0">Track incoming payments</p>
@@ -49,14 +49,14 @@
 <!-- Summary Cards -->
 <div class="row mb-4">
     <div class="col-md-4 mb-3">
-        <div class="summary-card slide-up">
+        <div class="summary-card slide-up" style="background: var(--success-gradient);">
             <i class="fas fa-dollar-sign fa-2x mb-3"></i>
             <h5 class="card-title">Total Billable</h5>
             <p class="card-text">${{ overall_billable|floatformat:2|intcomma }}</p>
         </div>
     </div>
     <div class="col-md-4 mb-3">
-        <div class="summary-card slide-up" style="background: var(--success-gradient); animation-delay: 0.1s;">
+        <div class="summary-card slide-up" style="background: var(--primary-gradient); animation-delay: 0.1s;">
             <i class="fas fa-credit-card fa-2x mb-3"></i>
             <h5 class="card-title">Total Payments</h5>
             <p class="card-text">${{ overall_payments|floatformat:2|intcomma }}</p>
@@ -81,20 +81,20 @@
                 </h5>
                 
                 <div class="action-buttons">
-                    <a href="{% url 'dashboard:project_list' %}" class="btn btn-primary">
+                    <a href="{% url 'dashboard:project_list' %}" class="btn btn-info">
                         <i class="fas fa-project-diagram me-2"></i>View All Projects
                     </a>
-                    
+
                     {% if first_project %}
                     <a href="{% url 'dashboard:select_job_entry_project' %}" class="btn btn-success">
                         <i class="fas fa-plus-circle me-2"></i>Quick Entry
                     </a>
-                    
-                    <a href="{% url 'dashboard:select_payment_project' %}" class="btn btn-warning">
+
+                    <a href="{% url 'dashboard:select_payment_project' %}" class="btn btn-primary">
                         <i class="fas fa-money-bill-wave me-2"></i>Add Payment
                     </a>
                     {% endif %}
-                    
+
                     <a href="{% url 'dashboard:contractor_report' %}" class="btn btn-secondary">
                         <i class="fas fa-file-alt me-2"></i>Summary Report
                     </a>
@@ -125,7 +125,7 @@
             <h5 class="card-title mb-0">
                 <i class="fas fa-project-diagram me-2"></i>Active Projects
             </h5>
-            <a href="{% url 'dashboard:project_list' %}" class="btn btn-outline-primary btn-sm">
+            <a href="{% url 'dashboard:project_list' %}" class="btn btn-outline-info btn-sm">
                 <i class="fas fa-eye me-1"></i>View All
             </a>
         </div>
@@ -167,12 +167,12 @@
                             <span class="badge bg-light text-dark">{{ project.start_date|date:"M d, Y" }}</span>
                         </td>
                         <td class="text-center">
-                            <span class="fw-semibold text-primary">
+                            <span class="fw-semibold text-success">
                                 ${{ project.total_billable|floatformat:0|intcomma }}
                             </span>
                         </td>
                         <td class="text-center">
-                            <span class="fw-semibold text-success">
+                            <span class="fw-semibold text-primary">
                                 ${{ project.total_payments|floatformat:0|intcomma }}
                             </span>
                         </td>
@@ -202,7 +202,7 @@
         
         {% if projects.count > 5 %}
         <div class="text-center mt-3">
-            <a href="{% url 'dashboard:project_list' %}" class="btn btn-outline-primary">
+            <a href="{% url 'dashboard:project_list' %}" class="btn btn-outline-info">
                 <i class="fas fa-arrow-right me-2"></i>View All Projects ({{ projects.count }} total)
             </a>
         </div>

--- a/jobtracker/dashboard/templates/dashboard/customer_report.html
+++ b/jobtracker/dashboard/templates/dashboard/customer_report.html
@@ -703,18 +703,18 @@ body {
     <div class="col-md-4">
         <div class="card text-center">
             <div class="card-body">
-                <i class="fas fa-dollar-sign fa-2x text-primary mb-2"></i>
+                <i class="fas fa-dollar-sign fa-2x text-success mb-2"></i>
                 <h6 class="card-title">Total Work</h6>
-                <h4 class="text-primary">${{ total|floatformat:2|intcomma }}</h4>
+                <h4 class="text-success">${{ total|floatformat:2|intcomma }}</h4>
             </div>
         </div>
     </div>
     <div class="col-md-4">
         <div class="card text-center">
             <div class="card-body">
-                <i class="fas fa-credit-card fa-2x text-success mb-2"></i>
+                <i class="fas fa-credit-card fa-2x text-primary mb-2"></i>
                 <h6 class="card-title">Payments</h6>
-                <h4 class="text-success">${{ total_payments|floatformat:2|intcomma }}</h4>
+                <h4 class="text-primary">${{ total_payments|floatformat:2|intcomma }}</h4>
             </div>
         </div>
     </div>
@@ -746,7 +746,7 @@ body {
                 <a href="{% url 'dashboard:add_job_entry' project.pk %}" class="btn btn-outline-warning">
                     <i class="fas fa-plus me-2"></i>Add Entry
                 </a>
-                <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-outline-info">
+                <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-outline-primary">
                     <i class="fas fa-money-bill-wave me-2"></i>Add Payment
                 </a>
             </div>

--- a/jobtracker/dashboard/templates/dashboard/estimate_list.html
+++ b/jobtracker/dashboard/templates/dashboard/estimate_list.html
@@ -37,7 +37,7 @@
             <div class="card-body">
                 <div class="row text-center mb-3">
                     <div class="col-4 border-end">
-                        <div class="fw-bold text-primary">${{ estimate.display_total_billable|floatformat:0|intcomma }}</div>
+                        <div class="fw-bold text-success">${{ estimate.display_total_billable|floatformat:0|intcomma }}</div>
                         <small class="text-muted">Total</small>
                     </div>
                     <div class="col-4 border-end">

--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -639,10 +639,10 @@
         <div class="row align-items-center">
             <div class="col-md-8">
                 <div class="d-flex gap-2 flex-wrap">
-                    <a href="{% url 'dashboard:add_job_entry' project.pk %}" class="btn btn-primary">
+                    <a href="{% url 'dashboard:add_job_entry' project.pk %}" class="btn btn-success">
                         <i class="fas fa-plus me-2"></i>Quick Entry
                     </a>
-                    <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-success">
+                    <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-primary">
                         <i class="fas fa-money-bill-wave me-2"></i>Record Payment
                     </a>
                     <a href="{% url 'dashboard:customer_report' project.pk %}" class="btn btn-warning text-white">
@@ -677,7 +677,7 @@
             <div class="metric-card">
                 <div class="metric-number text-primary">${{ total_payments|floatformat:2|intcomma }}</div>
                 <div class="metric-label">Payments Received</div>
-                <div class="metric-trend {% if payments %}text-success{% else %}text-muted{% endif %}">
+                <div class="metric-trend {% if payments %}text-primary{% else %}text-muted{% endif %}">
                     <i class="fas fa-credit-card me-1"></i>
                     {% if payments %}Last payment {{ payments.0.date|naturalday }}{% else %}No payments yet{% endif %}
                 </div>
@@ -717,7 +717,7 @@
     <div class="progress-section">
         <div class="d-flex justify-content-between align-items-center mb-3">
             <h4 class="mb-0">Payment Progress</h4>
-            <span class="badge bg-success fs-6">
+            <span class="badge bg-primary fs-6">
                 {% widthratio total_payments total_billable 100 as payment_percent %}
                 {{ payment_percent|default:0 }}% Paid
             </span>
@@ -873,7 +873,7 @@
             <div class="tab-content-card">
                 <div class="d-flex justify-content-between align-items-center mb-4">
                     <h5 class="mb-0">Payment History</h5>
-                    <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-success">
+                    <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-primary">
                         <i class="fas fa-plus me-2"></i>Record Payment
                     </a>
                 </div>
@@ -897,7 +897,7 @@
                                     <br><small class="text-muted">{{ payment.date|naturalday }}</small>
                                 </td>
                                 <td>
-                                    <span class="fs-5 fw-bold text-success">${{ payment.amount|floatformat:2|intcomma }}</span>
+                                    <span class="fs-5 fw-bold text-primary">${{ payment.amount|floatformat:2|intcomma }}</span>
                                 </td>
                                 <td>
                                     {% if payment.notes %}
@@ -925,7 +925,7 @@
                             <tr class="table-light">
                                 <td colspan="4" class="text-end">
                                     <strong>Total Payments:</strong>
-                                    <span class="fs-5 text-success">${{ total_payments|floatformat:2|intcomma }}</span>
+                                    <span class="fs-5 text-primary">${{ total_payments|floatformat:2|intcomma }}</span>
                                 </td>
                             </tr>
                         </tfoot>
@@ -936,7 +936,7 @@
                     <i class="fas fa-credit-card fa-3x text-muted mb-3"></i>
                     <h5 class="text-muted">No Payments</h5>
                     <p class="text-muted mb-3">No payments have been recorded for this project yet.</p>
-                    <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-success">
+                    <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-primary">
                         <i class="fas fa-plus me-2"></i>Record First Payment
                     </a>
                 </div>
@@ -1467,10 +1467,10 @@
 
 <!-- Floating Action Buttons -->
 <div class="floating-actions">
-    <a href="{% url 'dashboard:add_payment' project.pk %}" class="floating-btn success" title="Record Payment">
+    <a href="{% url 'dashboard:add_payment' project.pk %}" class="floating-btn primary" title="Record Payment">
         <i class="fas fa-money-bill-wave"></i>
     </a>
-    <a href="{% url 'dashboard:add_job_entry' project.pk %}" class="floating-btn primary" title="Add Job Entry">
+    <a href="{% url 'dashboard:add_job_entry' project.pk %}" class="floating-btn success" title="Add Job Entry">
         <i class="fas fa-plus"></i>
     </a>
     <a href="{% url 'dashboard:customer_report' project.pk %}" class="floating-btn warning" title="Generate Report">

--- a/jobtracker/dashboard/templates/dashboard/project_list.html
+++ b/jobtracker/dashboard/templates/dashboard/project_list.html
@@ -49,11 +49,11 @@
                 
                 <div class="d-flex text-center mb-3">
                     <div class="flex-fill border-end px-2">
-                        <div class="text-primary fw-bold">${{ project.total_billable|floatformat:0|intcomma }}</div>
+                        <div class="text-success fw-bold">${{ project.total_billable|floatformat:0|intcomma }}</div>
                         <small class="text-muted text-nowrap">Billable</small>
                     </div>
                     <div class="flex-fill border-end px-2">
-                        <div class="text-success fw-bold">${{ project.total_payments|floatformat:0|intcomma }}</div>
+                        <div class="text-primary fw-bold">${{ project.total_payments|floatformat:0|intcomma }}</div>
                         <small class="text-muted text-nowrap">Paid</small>
                     </div>
                     <div class="flex-fill px-2">
@@ -66,7 +66,7 @@
                 
                 <div class="progress mb-3" style="height: 6px;">
                     {% widthratio project.total_payments project.total_billable 100 as percentage %}
-                    <div class="progress-bar bg-success" role="progressbar" 
+                    <div class="progress-bar bg-primary" role="progressbar"
                          style="width: {{ percentage|default:0 }}%"
                          aria-valuenow="{{ percentage|default:0 }}" 
                          aria-valuemin="0" 
@@ -111,7 +111,7 @@
                         <a href="{% url 'dashboard:add_job_entry' project.pk %}" class="btn btn-outline-success btn-sm" title="Add Job Entry">
                             <i class="fas fa-plus"></i>
                         </a>
-                        <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-outline-info btn-sm" title="Add Payment">
+                        <a href="{% url 'dashboard:add_payment' project.pk %}" class="btn btn-outline-primary btn-sm" title="Add Payment">
                             <i class="fas fa-money-bill-wave"></i>
                         </a>
                         <form method="post" action="{% url 'dashboard:delete_project' project.pk %}" onsubmit="return confirm('Delete this project?');">
@@ -149,7 +149,7 @@
               </div>
               <div class="col-md-3 mb-3 mb-md-0">
                   <div class="border-md-end">
-                      <h4 class="text-info mb-0">${{ total_payments|floatformat:0|intcomma }}</h4>
+                      <h4 class="text-primary mb-0">${{ total_payments|floatformat:0|intcomma }}</h4>
                       <small class="text-muted d-block mt-0">Total Payments</small>
                   </div>
               </div>

--- a/jobtracker/dashboard/templates/dashboard/select_project.html
+++ b/jobtracker/dashboard/templates/dashboard/select_project.html
@@ -26,11 +26,11 @@
 
                     <div class="d-flex text-center mb-3">
                         <div class="flex-fill border-end px-2">
-                            <div class="text-primary fw-bold">${{ project.total_billable|floatformat:0|intcomma }}</div>
+                            <div class="text-success fw-bold">${{ project.total_billable|floatformat:0|intcomma }}</div>
                             <small class="text-muted text-nowrap">Billable</small>
                         </div>
                         <div class="flex-fill border-end px-2">
-                            <div class="text-success fw-bold">${{ project.total_payments|floatformat:0|intcomma }}</div>
+                            <div class="text-primary fw-bold">${{ project.total_payments|floatformat:0|intcomma }}</div>
                             <small class="text-muted text-nowrap">Paid</small>
                         </div>
                         <div class="flex-fill px-2">
@@ -43,7 +43,7 @@
 
                     <div class="progress mb-3" style="height: 6px;">
                         {% widthratio project.total_payments project.total_billable 100 as percentage %}
-                        <div class="progress-bar bg-success" role="progressbar"
+                        <div class="progress-bar bg-primary" role="progressbar"
                              style="width: {{ percentage|default:0 }}%"
                              aria-valuenow="{{ percentage|default:0 }}"
                              aria-valuemin="0" aria-valuemax="100">

--- a/jobtracker/static/css/squire.css
+++ b/jobtracker/static/css/squire.css
@@ -1,18 +1,18 @@
 /* Enhanced Squire Enterprises CSS with Optimized UX Design */
 
 :root {
-    /* Primary gradient inherits the info gradient for consistency */
-    --primary-gradient: var(--info-gradient);
-    
+    /* Distinct gradients for action variations */
+    --primary-gradient: linear-gradient(135deg, #0d6efd 0%, #0b5ed7 100%); /* Vibrant blue */
+
     /* Complementary gradients */
     --secondary-gradient: linear-gradient(135deg, #8b4513 0%, #a0522d 100%); /* Warm brown */
-    --success-gradient: var(--info-gradient); /* Align success with info gradient */
+    --success-gradient: linear-gradient(135deg, #198754 0%, #157347 100%); /* Classic green */
     --warning-gradient: linear-gradient(135deg, #daa520 0%, #ffd700 100%); /* Golden yellow */
-    --info-gradient: linear-gradient(135deg, #2e8b57 0%, #3cb371 100%); /* Sea green */
+    --info-gradient: linear-gradient(135deg, #0dcaf0 0%, #31d2f2 100%); /* Bright teal */
     --danger-gradient: linear-gradient(135deg, #8b4513 0%, #cd853f 100%); /* Rustic brown */
-    
+
     /* Core colors */
-    --primary-color: #3cb371; /* Medium sea green */
+    --primary-color: #0d6efd; /* Vibrant blue */
     --secondary-color: #3cb371; /* Medium sea green */
     --accent-color: #32cd32; /* Emerald accent */
     --warm-accent: #daa520; /* Golden accent */
@@ -44,10 +44,10 @@
     --radius-xl: 16px;
     
     /* Status colors */
-    --success-color: #32cd32;
+    --success-color: #198754;
     --warning-color: #daa520;
     --danger-color: #8b4513;
-    --info-color: #2e8b57;
+    --info-color: #0dcaf0;
 }
 
 /* Base Styles */
@@ -1214,7 +1214,7 @@ textarea:focus {
 
 .progress-fill {
     height: 100%;
-    background: var(--success-gradient);
+    background: var(--primary-gradient);
     border-radius: 6px;
     transition: width 1s ease;
     position: relative;


### PR DESCRIPTION
## Summary
- Give quick action buttons distinct colors for job entry, payments, and project views
- Align Total Payments summary card with Record Payment color
- Tidy project action buttons to keep color usage consistent

## Testing
- `python manage.py test` *(fails: sqlite3.OperationalError near "DO": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8f3e08648330b1744fab2e644dbb