### PR TITLE
Use green text for profit metrics

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/project_detail.html
+++ b/jobtracker/dashboard/templates/dashboard/project_detail.html
@@ -1136,7 +1136,7 @@
                                                 </div>
                                                 <div class="col-sm-3">
                                                     <div class="metric-box">
-                                                        <div class="metric-value text-primary">${{ labor_profit|floatformat:0|intcomma }}</div>
+                                                        <div class="metric-value text-success">${{ labor_profit|floatformat:0|intcomma }}</div>
                                                         <div class="metric-label">Profit</div>
                                                     </div>
                                                 </div>
@@ -1202,7 +1202,7 @@
                                                 </div>
                                                 <div class="col-sm-3">
                                                     <div class="metric-box">
-                                                        <div class="metric-value text-primary">${{ equipment_profit|floatformat:0|intcomma }}</div>
+                                                        <div class="metric-value text-success">${{ equipment_profit|floatformat:0|intcomma }}</div>
                                                         <div class="metric-label">Profit</div>
                                                     </div>
                                                 </div>
@@ -1268,7 +1268,7 @@
                                                 </div>
                                                 <div class="col-sm-3">
                                                     <div class="metric-box">
-                                                        <div class="metric-value text-primary">${{ material_profit|floatformat:0|intcomma }}</div>
+                                                        <div class="metric-value text-success">${{ material_profit|floatformat:0|intcomma }}</div>
                                                         <div class="metric-label">Profit</div>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
## Summary
- Match profit text color with progress bar by using green `text-success`

## Testing
- `python jobtracker/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bf95a3b2548330bd0a609a1049dcfe