### PR TITLE
Reorder contractor quick actions

### DIFF
--- a/jobtracker/dashboard/templates/dashboard/contractor_summary.html
+++ b/jobtracker/dashboard/templates/dashboard/contractor_summary.html
@@ -81,19 +81,19 @@
                 </h5>
                 
                 <div class="action-buttons">
-                    <a href="{% url 'dashboard:project_list' %}" class="btn btn-info">
-                        <i class="fas fa-project-diagram me-2"></i>View All Projects
-                    </a>
-
                     {% if first_project %}
-                    <a href="{% url 'dashboard:select_job_entry_project' %}" class="btn btn-primary">
+                    <a href="{% url 'dashboard:select_job_entry_project' %}" class="btn btn-success">
                         <i class="fas fa-plus-circle me-2"></i>Quick Entry
                     </a>
 
                     <a href="{% url 'dashboard:select_payment_project' %}" class="btn btn-primary">
-                        <i class="fas fa-money-bill-wave me-2"></i>Add Payment
+                        <i class="fas fa-money-bill-wave me-2"></i>Enter Payments
                     </a>
                     {% endif %}
+
+                    <a href="{% url 'dashboard:project_list' %}" class="btn btn-info">
+                        <i class="fas fa-project-diagram me-2"></i>View All Projects
+                    </a>
 
                     <a href="{% url 'dashboard:contractor_report' %}" class="btn btn-secondary">
                         <i class="fas fa-file-alt me-2"></i>Summary Report

--- a/jobtracker/dashboard/tests.py
+++ b/jobtracker/dashboard/tests.py
@@ -336,13 +336,13 @@ class ReportButtonPlacementTests(TestCase):
         self.assertNotContains(response, "Contractor Summary Report")
         self.assertNotContains(response, "Customer Reports")
         self.assertNotContains(response, "Quick Entry")
-        self.assertNotContains(response, "Add Payment")
+        self.assertNotContains(response, "Enter Payments")
 
     def test_contractor_summary_shows_job_and_payment_buttons_with_project(self):
         self.contractor.projects.create(name="Proj", start_date="2024-01-01")
         response = self.client.get(reverse("dashboard:contractor_summary"))
         self.assertContains(response, "Quick Entry")
-        self.assertContains(response, "Add Payment")
+        self.assertContains(response, "Enter Payments")
 
     def test_project_list_shows_contractor_summary_report_button(self):
         self.contractor.projects.create(name="Proj", start_date="2024-01-01")


### PR DESCRIPTION
## Summary
- reorder contractor dashboard quick-action buttons and make Quick Entry green
- update tests for renamed Enter Payments button

## Testing
- `python manage.py test` (fails: OperationalError near "DO" syntax error)


------
https://chatgpt.com/codex/tasks/task_e_68bf953221588330bc72127d064ae347